### PR TITLE
Update pip to avoid psycopg2 install issue

### DIFF
--- a/deploy/indexer.Dockerfile
+++ b/deploy/indexer.Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 RUN apt-get install -y git cmake wget python3 python3-pip
+RUN python3 -m pip install -U pip
 
 # python requirements
 ADD deploy/requirements.txt /tmp/requirements.txt

--- a/deploy/jupyter.Dockerfile
+++ b/deploy/jupyter.Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 RUN apt-get install -y git cmake wget python3 python3-pip
+RUN python3 -m pip install -U pip
 
 RUN python3 -m pip install jupyter notebook
 

--- a/deploy/scheduler.Dockerfile
+++ b/deploy/scheduler.Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 RUN apt-get install -y git cmake wget python3 python3-pip
+RUN python3 -m pip install -U pip
 
 # python requirements
 ADD deploy/requirements.txt /tmp/requirements.txt

--- a/deploy/web.Dockerfile
+++ b/deploy/web.Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata
 RUN apt-get install -y git cmake wget python3 python3-pip
+RUN python3 -m pip install -U pip
 
 # python requirements
 ADD deploy/requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
Minor fix to avoid psycopg2 install issue. Without pip upgrade I get such error:

```
#10 8.369   Downloading psycopg2-binary-2.9.5.tar.gz (384 kB)
#10 8.791     ERROR: Command errored out with exit status 1:
#10 8.791      command: /usr/bin/python3 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-ikvwy7u8/psycopg2-binary/setup.py'"'"'; __file__='"'"'/tmp/pip-install-ikvwy7u8/psycopg2-binary/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-ikvwy7u8/psycopg2-binary/pip-egg-info
#10 8.791          cwd: /tmp/pip-install-ikvwy7u8/psycopg2-binary/
#10 8.791     Complete output (23 lines):
#10 8.791     running egg_info
#10 8.791     creating /tmp/pip-install-ikvwy7u8/psycopg2-binary/pip-egg-info/psycopg2_binary.egg-info
#10 8.791     writing /tmp/pip-install-ikvwy7u8/psycopg2-binary/pip-egg-info/psycopg2_binary.egg-info/PKG-INFO
#10 8.791     writing dependency_links to /tmp/pip-install-ikvwy7u8/psycopg2-binary/pip-egg-info/psycopg2_binary.egg-info/dependency_links.txt
#10 8.791     writing top-level names to /tmp/pip-install-ikvwy7u8/psycopg2-binary/pip-egg-info/psycopg2_binary.egg-info/top_level.txt
#10 8.791     writing manifest file '/tmp/pip-install-ikvwy7u8/psycopg2-binary/pip-egg-info/psycopg2_binary.egg-info/SOURCES.txt'
#10 8.791
#10 8.791     Error: pg_config executable not found.
#10 8.791
#10 8.791     pg_config is required to build psycopg2 from source.  Please add the directory
#10 8.791     containing pg_config to the $PATH or specify the full executable path with the
#10 8.791     option:
#10 8.791
```

