### PR TITLE
Add liteserver index config & anchors to docker compose depens_on

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Recommended hardware: 2 CPU, 16 GB RAM, 200 GB disk, SSD recommended.
 Prerequisites: docker, docker-compose
 
   - Setup environment variables:
-    - `TON_INDEXER_LITE_SERVER_CONFIG` *(required)* — path to liteserver config file with your liteserver. If config file contains more than 1 lite server the first one will be used.
+    - `TON_INDEXER_LITE_SERVER_CONFIG` *(required)* — path to liteserver config file with your liteserver. If config file contains more than 1 lite server `LITESERVER_INDEX_BACKWARD` / `LITESERVER_INDEX_FORWARD` will be used.
+    - `LITESERVER_INDEX_BACKWARD` / `LITESERVER_INDEX_FORWARD` *(default: 0)* — index of liteserver from the config file for backward/forward indexer
     - `TON_INDEXER_START_SEQNO` *(required)* — masterchain seqno to start with. The service starts indexing from this value in 2 directions: to the latest blocks and to the earliest blocks.
     - `TON_INDEXER_BOTTOM_SEQNO` *(required)* — the earliest masterchain seqno. The service will not index blocks earlier this value. Make sure that this seqno exists in lite server that you are using.
     - `TON_INDEXER_HTTP_PORT` *(default: 80)* — port for API webserver.

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -2,6 +2,7 @@ webserver:
   api_root_path: ${ROOT_PATH}
 indexer:
   liteserver_config: /run/secrets/tonlib_config
+  ls_index: ${LITESERVER_INDEX}
   use_ext_method: ${USE_GET_BLOCK_TRANSACTIONS_EXT}
   cdll_path: ./config/libtonlibjson.so.0.5
   workers_count: ${WORKERS_COUNT}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,12 +24,18 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       USE_GET_BLOCK_TRANSACTIONS_EXT: ${TON_INDEXER_USE_GET_BLOCK_TRANSACTIONS_EXT:-0}
+      LITESERVER_INDEX: ${LITESERVER_INDEX_BACKWARD:-0}
     secrets:
       - postgres_password
       - tonlib_config
     depends_on:
-      - rabbitmq
-      - postgres
+      &common-depends-on
+      rabbitmq:
+        condition: service_started
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_healthy
   backward_scheduler:
     build:
       context: .
@@ -46,12 +52,10 @@ services:
       WORKERS_COUNT: ${TON_INDEXER_BACKWARD_WORKERS_COUNT:-5}
     secrets:
       - postgres_password
-      - tonlib_config
     depends_on:
+      <<: *common-depends-on
       backward_indexer:
         condition: service_started
-      postgres:
-        condition: service_healthy
   forward_indexer:
     build:
       context: .
@@ -64,12 +68,11 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       USE_GET_BLOCK_TRANSACTIONS_EXT: ${TON_INDEXER_USE_GET_BLOCK_TRANSACTIONS_EXT:-0}
+      LITESERVER_INDEX: ${LITESERVER_INDEX_FORWARD:-0}
     secrets:
       - postgres_password
       - tonlib_config
-    depends_on:
-      - rabbitmq
-      - postgres
+    depends_on: *common-depends-on
   forward_scheduler:
     build:
       context: .
@@ -86,12 +89,10 @@ services:
       WORKERS_COUNT: ${TON_INDEXER_FORWARD_WORKERS_COUNT:-2}
     secrets:
       - postgres_password
-      - tonlib_config
     depends_on:
+      <<: *common-depends-on
       forward_indexer:
         condition: service_started
-      postgres:
-        condition: service_healthy
   rabbitmq:
     image: rabbitmq
     restart: unless-stopped

--- a/indexer/tasks.py
+++ b/indexer/tasks.py
@@ -24,8 +24,8 @@ def configure_worker(signal=None, sender=None, **kwargs):
     global loop
     global index_worker
     loop = asyncio.get_event_loop()
-    index_worker = IndexWorker(loop, 
-                               0, 
+    index_worker = IndexWorker(loop,
+                               ls_index=settings.indexer.ls_index,
                                use_ext_method=settings.indexer.use_ext_method, 
                                cdll_path=settings.indexer.cdll_path)
 


### PR DESCRIPTION
When using liteserver config from the mainnet it is useful to have ability to pass different ``ls_index`` to backward and forward indexers:
* Not all liteservers provides archive data, for example default one does not
* Using separate liteservers for forward/backward could improve network performance


Also this PR contains minor fixes to ``docker-compose.yaml`` for reusing ``depends_on`` with YAML anchors