### PR TITLE
Fix sqlalchemy version conflict

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -13,7 +13,7 @@ ring
 git+https://github.com/toncenter/tvm_valuetypes.git
 celery[redis]
 psycopg2-binary
-sqlalchemy[asyncio]
+sqlalchemy[asyncio]==1.4.46
 asyncpg
 sqlalchemy-utils
 tqdm


### PR DESCRIPTION
SQLAlchemy 2.0.0 released on January 26 and it is not compatible with sqlalchemy-utils (see [sqlalchemy-utils/issues/676](https://github.com/kvesteri/sqlalchemy-utils/issues/676)). Without this fixing sqlalchemy version DB wouldn't be created:
```
packages/sqlalchemy_utils/functions/database.py", line 569, in create_database
ton-indexer-forward_scheduler-1  |     quote(engine, database),
ton-indexer-forward_scheduler-1  |   File "/usr/local/lib/python3.8/dist-packages/sqlalchemy_utils/functions/orm.py", line 528, in quote
ton-indexer-forward_scheduler-1  |     dialect = get_bind(mixed).dialect
ton-indexer-forward_scheduler-1  |   File "/usr/local/lib/python3.8/dist-packages/sqlalchemy_utils/functions/orm.py", line 339, in get_bind
ton-indexer-forward_scheduler-1  |     raise TypeError(
ton-indexer-forward_scheduler-1  | TypeError: This method accepts only Session, Engine, Connection and declarative model objects.
```