### PR TITLE
fix issue TypeError: issubclass() arg 1 must be a class during server startup

### DIFF
--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -17,6 +17,7 @@ sqlalchemy[asyncio]==1.4.46
 asyncpg
 sqlalchemy-utils
 tqdm
+typing_extensions==4.5.0
 requests
 asgiref
 pytonlib==0.0.46


### PR DESCRIPTION
[Fix issue #26](https://github.com/toncenter/ton-indexer/issues/26)
feat: requirements.txt add typing_extensions version 4.5.0 for fix TypeError: issubclass() arg 1 must be a class error