### PR TITLE
Add flag `include_raw_msg_body`

### DIFF
--- a/api/api_v1/main.py
+++ b/api/api_v1/main.py
@@ -75,6 +75,7 @@ async def get_transactions_by_address(
     sort: str = Query("desc", description="Use `asc` to get oldest transactions first and `desc` to get newest first."),
     include_msg_body: bool = Query(False, description="Whether return full message body or not"),
     include_block: bool = Query(False, description="If true response contains corresponding block for each transaction"),
+    include_raw_msg_body: bool = Query(False, description="Whether return raw message body or not"),
     db: Session = Depends(get_db)
     ):
     """
@@ -84,8 +85,8 @@ async def get_transactions_by_address(
         raw_address = detect_address(address)["raw_form"]
     except Exception:
         raise HTTPException(status_code=416, detail="Invalid address")
-    db_transactions = await db.run_sync(crud.get_transactions_by_address, raw_address, start_utime, end_utime, limit, offset, sort, include_msg_body, include_block)
-    return [schemas.Transaction.transaction_from_orm(t, include_msg_body, include_block) for t in db_transactions]
+    db_transactions = await db.run_sync(crud.get_transactions_by_address, raw_address, start_utime, end_utime, limit, offset, sort, include_msg_body or include_raw_msg_body, include_block)
+    return [schemas.Transaction.transaction_from_orm(t, include_msg_body, include_block, include_raw_msg_body) for t in db_transactions]
 
 @router.get('/getTransactionsInBlock', response_model=List[schemas.Transaction])
 async def get_transactions_in_block(

--- a/api/api_v1/main.py
+++ b/api/api_v1/main.py
@@ -57,13 +57,14 @@ async def get_transactions_by_masterchain_seqno(
     seqno: int = Query(..., description="Masterchain seqno", ge=0, le=UINT32_MAX),
     include_msg_body: bool = Query(False, description="Whether return full message body or not"),
     include_block: bool = Query(False, description="If true response contains corresponding block for each transaction"),
+    include_raw_msg_body: bool = Query(False, description="Whether return raw message body or not"),
     db: Session = Depends(get_db)
     ):
     """
     Get transactions by masterchain seqno across all workchains and shardchains.
     """
-    db_transactions = await db.run_sync(crud.get_transactions_by_masterchain_seqno, seqno, include_msg_body, include_block)
-    return [schemas.Transaction.transaction_from_orm(t, include_msg_body, include_block) for t in db_transactions]
+    db_transactions = await db.run_sync(crud.get_transactions_by_masterchain_seqno, seqno, include_msg_body or include_raw_msg_body, include_block)
+    return [schemas.Transaction.transaction_from_orm(t, include_msg_body, include_block, include_raw_msg_body) for t in db_transactions]
 
 @router.get('/getTransactionsByAddress', response_model=List[schemas.Transaction])
 async def get_transactions_by_address(

--- a/api/api_v1/schemas.py
+++ b/api/api_v1/schemas.py
@@ -276,6 +276,9 @@ def get_msg_body_annotation(body, op, source_interfaces, dest_interfaces):
 
     return result
 
+def get_msg_body_raw_annotation(body):
+    return RawBody(boc=body)
+
 class Message(BaseModel):
     source: str
     destination: str
@@ -338,10 +341,13 @@ class Transaction(BaseModel):
     block: Optional[Block] = None
 
     @classmethod
-    def transaction_from_orm(cls, obj, include_msg_bodies, include_block):
+    def transaction_from_orm(cls, obj, include_msg_bodies, include_block, include_raw_msg_bodies=False):
         if obj.in_msg is not None:
             body_model = None
-            if include_msg_bodies:
+            if include_raw_msg_bodies:
+                body = obj.in_msg.content.body
+                body_model = get_msg_body_raw_annotation(body)
+            elif include_msg_bodies:
                 body = obj.in_msg.content.body
                 op = obj.in_msg.op
                 source_interfaces = obj.in_msg.out_tx.account_code_hash_rel.interfaces if obj.in_msg.out_tx else []
@@ -354,7 +360,10 @@ class Transaction(BaseModel):
         out_msgs = []
         for out_msg in obj.out_msgs:
             body_model = None
-            if include_msg_bodies:
+            if include_raw_msg_bodies:
+                body = obj.in_msg.content.body
+                body_model = get_msg_body_raw_annotation(body)
+            elif include_msg_bodies:
                 body = out_msg.content.body
                 op = out_msg.op
                 source_interfaces = obj.account_code_hash_rel.interfaces


### PR DESCRIPTION
Hi! We really miss this flag. I added it, but unfortunately I can't check it due to an error in the web container.

```
2023-11-08 15:15:40   File "/usr/src/ton-indexer/api/api_v1/main.py", line 11, in <module>
2023-11-08 15:15:40     from . import schemas
2023-11-08 15:15:40   File "/usr/src/ton-indexer/api/api_v1/schemas.py", line 35, in <module>
2023-11-08 15:15:40     class MsgAddressInt(BaseModel):
2023-11-08 15:15:40   File "pydantic/main.py", line 197, in pydantic.main.ModelMetaclass.__new__
2023-11-08 15:15:40   File "pydantic/fields.py", line 506, in pydantic.fields.ModelField.infer
2023-11-08 15:15:40   File "pydantic/fields.py", line 436, in pydantic.fields.ModelField.__init__
2023-11-08 15:15:40   File "pydantic/fields.py", line 552, in pydantic.fields.ModelField.prepare
2023-11-08 15:15:40   File "pydantic/fields.py", line 668, in pydantic.fields.ModelField._type_analysis
2023-11-08 15:15:40   File "/usr/lib/python3.8/typing.py", line 774, in __subclasscheck__
2023-11-08 15:15:40     return issubclass(cls, self.__origin__)
2023-11-08 15:15:40 TypeError: issubclass() arg 1 must be a class
```

It doesn't seem to be related to my changes. Please merge this so that we can switch to this API from the ton-http-api, which is currently not working correctly.