### PR TITLE
Doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ TON node stores data in a key-value database RocksDB.  While RocksDB excels in s
 
 TON Indexer stack consists of:
 1. `postgres`: PostgreSQL server to store indexed data and perform queries.
-2. `index-api`: FastAPI server with convenient endpoints to access the database.
+2. `index-api`: [Fiber](https://github.com/gofiber/fiber) server with convenient endpoints to access the database.
 3. `event-classifier`: trace classification service.
 4. `index-worker`: TON Index worker to read and parse data from TON node database. This service must be run on the machine with a working TON Node.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Do the following steps to setup TON Indexer:
 
 ## Swagger
 
-To test API, built-in swagger can be used. It is available after running `docker compose` at `localhost:8081`
+To test API, built-in swagger can be used. It is available after running `docker compose` at `localhost:8081/api/v3`
 
 # FAQ
 


### PR DESCRIPTION
- **Change `index-api` service descriptions**: If you follow the documentation, the Go `Fiber` server is running when index-api is deployed instead of `FastAPI`
- **Fix wrong swagger route**: it's not an clear route, the first thing that comes to mind is that the api doesn't work