### PR TITLE
Fix indexer stuck after multiple reschedules of seqno

### DIFF
--- a/ton-index-worker/ton-index-postgres/src/IndexScheduler.cpp
+++ b/ton-index-worker/ton-index-postgres/src/IndexScheduler.cpp
@@ -203,7 +203,7 @@ void IndexScheduler::got_newest_mc_seqno(std::uint32_t newest_mc_seqno) {
         if (should_skip) {
             skipped_count++;
         } else if (in_range) {
-            queued_seqnos_.push(seqno);
+            queued_seqnos_.push_back(seqno);
         }
     }
     if (skipped_count > 0) {
@@ -246,7 +246,7 @@ void IndexScheduler::reschedule_seqno(std::uint32_t mc_seqno, bool silent) {
         LOG(WARNING) << "Rescheduling seqno " << mc_seqno;
     }
     processing_seqnos_.erase(mc_seqno);
-    queued_seqnos_.push(mc_seqno);
+    queued_seqnos_.push_front(mc_seqno);
 }
 
 void IndexScheduler::seqno_fetched(std::uint32_t mc_seqno, MasterchainBlockDataState block_data_state) {
@@ -377,7 +377,7 @@ void IndexScheduler::schedule_next_seqnos() {
     LOG(DEBUG) << "Scheduling next seqnos. Current tasks: " << processing_seqnos_.size();
     while (!queued_seqnos_.empty() && (processing_seqnos_.size() < max_active_tasks_)) {
         std::uint32_t seqno = queued_seqnos_.front();
-        queued_seqnos_.pop();
+        queued_seqnos_.pop_front();
         schedule_seqno(seqno);
     }
 

--- a/ton-index-worker/ton-index-postgres/src/IndexScheduler.h
+++ b/ton-index-worker/ton-index-postgres/src/IndexScheduler.h
@@ -16,7 +16,7 @@ using Detector = InterfacesDetector<JettonWalletDetectorR, JettonMasterDetectorR
 
 class IndexScheduler: public td::actor::Actor {
 private:
-  std::queue<std::uint32_t> queued_seqnos_;
+  std::deque<std::uint32_t> queued_seqnos_;
   std::set<std::uint32_t> processing_seqnos_;
   std::set<std::uint32_t> indexed_seqnos_;
 


### PR DESCRIPTION
When TON node is lagging indexer might reschedule interval of seqnos multiple times, ending up in situation when seqno X is expected in TraceAssembler, but scheduler processed seqnos `[X+1, X+n]` and X is scheduled in the `queued_seqnos_`. To fix it I push rescheduled seqno to front of the queue (now deque).