### PR TITLE
Parse contract methods via disasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,9 @@ project(ton-indexer LANGUAGES CXX Go)
 
 include(cmake/golang.cmake)
 
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 add_subdirectory(ton-emulate-go)
 add_subdirectory(ton-index-go)
 add_subdirectory(ton-metadata-fetcher)

--- a/ton-index-worker/ton-index-postgres/src/BlockInterfacesDetector.h
+++ b/ton-index-worker/ton-index-postgres/src/BlockInterfacesDetector.h
@@ -16,7 +16,7 @@ private:
     ParsedBlockPtr block_;
     td::Promise<ParsedBlockPtr> promise_;
     std::unordered_map<block::StdAddress, std::vector<BlockchainInterfaceV2>> interfaces_{};
-    std::unordered_map<td::Bits256, ContractMethodsData> contract_methods_{};
+    std::unordered_multimap<td::Bits256, uint64_t> contract_methods_{};
     td::Timer timer_{true};
 public:
     BlockInterfaceProcessor(ParsedBlockPtr block, td::Promise<ParsedBlockPtr> promise) : 
@@ -40,11 +40,9 @@ public:
                     if (contract_methods_.find(code_hash) == contract_methods_.end()) {
                         auto methods_result = parse_contract_methods(account_state.code);
                         if (methods_result.is_ok()) {
-                            ContractMethodsData methods_data;
-                            methods_data.code_hash = code_hash;
-                            methods_data.method_ids = methods_result.move_as_ok();
-                            methods_data.timestamp = account_state.timestamp;
-                            contract_methods_[code_hash] = std::move(methods_data);
+                            for (auto method_id : methods_result.move_as_ok()) {
+                                contract_methods_.emplace(code_hash, method_id);
+                            }
                         }
                     }
                 }

--- a/ton-index-worker/ton-index-postgres/src/InsertManagerPostgres.cpp
+++ b/ton-index-worker/ton-index-postgres/src/InsertManagerPostgres.cpp
@@ -407,7 +407,6 @@ void InsertBatchPostgres::alarm() {
     insert_under_mutex_query += insert_nft_items(txn);
     insert_under_mutex_query += insert_getgems_nft_auctions(txn);
     insert_under_mutex_query += insert_getgems_nft_sales(txn);
-    insert_under_mutex_query += insert_contract_methods(txn);
     insert_under_mutex_query += insert_latest_account_states(txn);
     
     td::Timer commit_timer{true};
@@ -418,6 +417,12 @@ void InsertBatchPostgres::alarm() {
       commit_timer.resume();
       txn.commit();
       commit_timer.pause();
+    }
+
+    {
+      pqxx::work txn2(c);
+      insert_contract_methods(txn2);
+      txn2.commit();
     }
 
     for(auto& task : insert_tasks_) {

--- a/ton-index-worker/ton-index-postgres/src/InsertManagerPostgres.h
+++ b/ton-index-worker/ton-index-postgres/src/InsertManagerPostgres.h
@@ -77,6 +77,6 @@ private:
   std::string insert_nft_items(pqxx::work &txn);
   std::string insert_getgems_nft_auctions(pqxx::work &txn);
   std::string insert_getgems_nft_sales(pqxx::work &txn);
-  std::string insert_contract_methods(pqxx::work &txn);
+  void insert_contract_methods(pqxx::work &txn);
   void insert_traces(pqxx::work &txn, bool with_copy);
 };

--- a/ton-index-worker/ton-trace-emulator/src/EmulationContext.h
+++ b/ton-index-worker/ton-trace-emulator/src/EmulationContext.h
@@ -167,9 +167,9 @@ private:
             account_state.block_lt = shard_state.lt;
 
             std::lock_guard<std::mutex> lock(emulated_accounts_mutex_);
-            emulated_accounts_.insert({address, account_state});
+            auto it = emulated_accounts_.insert({address, std::move(account_state)});
 
-            return account_state;
+            return it->second;
         }
         return td::Status::Error("Account not found in shard_states");
     }

--- a/ton-index-worker/ton-trace-emulator/src/Serializer.hpp
+++ b/ton-index-worker/ton-trace-emulator/src/Serializer.hpp
@@ -68,7 +68,7 @@ struct TrComputePhase_vm {
 using TrComputePhase = std::variant<TrComputePhase_skipped, 
                                     TrComputePhase_vm>;
 
-struct StorageUsedShort {
+struct StorageUsed {
   uint64_t cells;
   uint64_t bits;
 
@@ -89,7 +89,7 @@ struct TrActionPhase {
   uint16_t skipped_actions;
   uint16_t msgs_created;
   td::Bits256 action_list_hash;
-  StorageUsedShort tot_msg_size;
+  StorageUsed tot_msg_size;
 
   MSGPACK_DEFINE(success, valid, no_funds, status_change, total_fwd_fees, total_action_fees, result_code, result_arg, tot_actions, spec_actions, skipped_actions, msgs_created, action_list_hash, tot_msg_size);
 };
@@ -101,14 +101,14 @@ struct TrBouncePhase_negfunds {
 };
 
 struct TrBouncePhase_nofunds {
-  StorageUsedShort msg_size;
+  StorageUsed msg_size;
   uint64_t req_fwd_fees;
 
   MSGPACK_DEFINE(msg_size, req_fwd_fees);
 };
 
 struct TrBouncePhase_ok {
-  StorageUsedShort msg_size;
+  StorageUsed msg_size;
   uint64_t msg_fees;
   uint64_t fwd_fees;
 
@@ -392,12 +392,12 @@ td::Result<TrComputePhase> parse_tr_compute_phase(vm::CellSlice& cs) {
   return td::Status::OK();
 }
 
-td::Result<StorageUsedShort> parse_storage_used_short(vm::CellSlice& cs) {
-  block::gen::StorageUsedShort::Record info;
+td::Result<StorageUsed> parse_storage_used_short(vm::CellSlice& cs) {
+  block::gen::StorageUsed::Record info;
   if (!tlb::unpack(cs, info)) {
-    return td::Status::Error("Error unpacking StorageUsedShort");
+    return td::Status::Error("Error unpacking StorageUsed");
   }
-  StorageUsedShort res;
+  StorageUsed res;
   res.bits = block::tlb::t_VarUInteger_7.as_uint(*info.bits);
   res.cells = block::tlb::t_VarUInteger_7.as_uint(*info.cells);
   return res;

--- a/ton-index-worker/tondb-scanner/src/DataParser.cpp
+++ b/ton-index-worker/tondb-scanner/src/DataParser.cpp
@@ -360,12 +360,12 @@ td::Result<schema::TrComputePhase> ParseQuery::parse_tr_compute_phase(vm::CellSl
   return td::Status::OK();
 }
 
-td::Result<schema::StorageUsedShort> ParseQuery::parse_storage_used_short(vm::CellSlice& cs) {
-  block::gen::StorageUsedShort::Record info;
+td::Result<schema::StorageUsed> ParseQuery::parse_storage_used(vm::CellSlice& cs) {
+  block::gen::StorageUsed::Record info;
   if (!tlb::unpack(cs, info)) {
-    return td::Status::Error("Error unpacking StorageUsedShort");
+    return td::Status::Error("Error unpacking StorageUsed");
   }
-  schema::StorageUsedShort res;
+  schema::StorageUsed res;
   res.bits = block::tlb::t_VarUInteger_7.as_uint(*info.bits);
   res.cells = block::tlb::t_VarUInteger_7.as_uint(*info.cells);
   return res;
@@ -399,7 +399,7 @@ td::Result<schema::TrActionPhase> ParseQuery::parse_tr_action_phase(vm::CellSlic
   res.skipped_actions = info.skipped_actions;
   res.msgs_created = info.msgs_created;
   res.action_list_hash = info.action_list_hash;
-  TRY_RESULT_ASSIGN(res.tot_msg_size, parse_storage_used_short(info.tot_msg_size.write()));
+  TRY_RESULT_ASSIGN(res.tot_msg_size, parse_storage_used(info.tot_msg_size.write()));
   return res;
 }
 
@@ -419,7 +419,7 @@ td::Result<schema::TrBouncePhase> ParseQuery::parse_tr_bounce_phase(vm::CellSlic
         return td::Status::Error("Error unpacking tr_phase_bounce_nofunds");
       }
       schema::TrBouncePhase_nofunds res;
-      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used_short(nofunds.msg_size.write()));
+      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used(nofunds.msg_size.write()));
       res.req_fwd_fees = block::tlb::t_Grams.as_integer_skip(nofunds.req_fwd_fees.write());
       return res;
     }
@@ -429,7 +429,7 @@ td::Result<schema::TrBouncePhase> ParseQuery::parse_tr_bounce_phase(vm::CellSlic
         return td::Status::Error("Error unpacking tr_phase_bounce_ok");
       }
       schema::TrBouncePhase_ok res;
-      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used_short(ok.msg_size.write()));
+      TRY_RESULT_ASSIGN(res.msg_size, parse_storage_used(ok.msg_size.write()));
       res.msg_fees = block::tlb::t_Grams.as_integer_skip(ok.msg_fees.write());
       res.fwd_fees = block::tlb::t_Grams.as_integer_skip(ok.fwd_fees.write());
       return res;

--- a/ton-index-worker/tondb-scanner/src/DataParser.h
+++ b/ton-index-worker/tondb-scanner/src/DataParser.h
@@ -27,7 +27,7 @@ private:
   td::Result<schema::TrStoragePhase> parse_tr_storage_phase(vm::CellSlice& cs);
   td::Result<schema::TrCreditPhase> parse_tr_credit_phase(vm::CellSlice& cs);
   td::Result<schema::TrComputePhase> parse_tr_compute_phase(vm::CellSlice& cs);
-  td::Result<schema::StorageUsedShort> parse_storage_used_short(vm::CellSlice& cs);
+  td::Result<schema::StorageUsed> parse_storage_used(vm::CellSlice& cs);
   td::Result<schema::TrActionPhase> parse_tr_action_phase(vm::CellSlice& cs);
   td::Result<schema::TrBouncePhase> parse_tr_bounce_phase(vm::CellSlice& cs);
   td::Result<schema::SplitMergeInfo> parse_split_merge_info(td::Ref<vm::CellSlice>& cs);

--- a/ton-index-worker/tondb-scanner/src/IndexData.h
+++ b/ton-index-worker/tondb-scanner/src/IndexData.h
@@ -565,12 +565,6 @@ struct GetGemsNftFixPriceSaleData {
   td::Bits256 data_hash;
 };
 
-struct ContractMethodsData {
-  td::Bits256 code_hash;
-  std::vector<unsigned long long> method_ids;
-  uint64_t timestamp;
-};
-
 //
 // Containers
 //
@@ -674,7 +668,7 @@ struct ParsedBlock {
     return result;
   }
 
-  std::unordered_map<td::Bits256, ContractMethodsData> contract_methods_;
+  std::unordered_multimap<td::Bits256, uint64_t> contract_methods_;
 };
 
 using ParsedBlockPtr = std::shared_ptr<ParsedBlock>;

--- a/ton-index-worker/tondb-scanner/src/IndexData.h
+++ b/ton-index-worker/tondb-scanner/src/IndexData.h
@@ -71,7 +71,7 @@ struct TrComputePhase_vm {
 using TrComputePhase = std::variant<TrComputePhase_skipped, 
                                     TrComputePhase_vm>;
 
-struct StorageUsedShort {
+struct StorageUsed {
   uint64_t cells;
   uint64_t bits;
 };
@@ -90,19 +90,19 @@ struct TrActionPhase {
   uint16_t skipped_actions;
   uint16_t msgs_created;
   td::Bits256 action_list_hash;
-  StorageUsedShort tot_msg_size;
+  StorageUsed tot_msg_size;
 };
 
 struct TrBouncePhase_negfunds {
 };
 
 struct TrBouncePhase_nofunds {
-  StorageUsedShort msg_size;
+  StorageUsed msg_size;
   td::RefInt256 req_fwd_fees;
 };
 
 struct TrBouncePhase_ok {
-  StorageUsedShort msg_size;
+  StorageUsed msg_size;
   td::RefInt256 msg_fees;
   td::RefInt256 fwd_fees;
 };


### PR DESCRIPTION
Works for FunC/Tact contracts.

Adds table `contract_methods`:
- **`code_hash`** `text`
- **`methods`** `bigint[]`
- **`timestamp`** `bigint`

Possible enhancements:
- Add cache
- Skip classic Detectors when there's no their get methods in parsed result
- Add some known contracts in Fift-Asm with their methods. Like [wallet-v3](https://github.com/ton-blockchain/ton/blob/master/crypto/smartcont/wallet-v3-code.fif)
