### PR TITLE
Add swaggertype to DecodedCustomPayload fields

### DIFF
--- a/ton-index-go/index/models.go
+++ b/ton-index-go/index/models.go
@@ -361,10 +361,10 @@ type NFTTransfer struct {
 	NewOwner              AccountAddress   `json:"new_owner"`
 	ResponseDestination   *AccountAddress  `json:"response_destination"`
 	CustomPayload         *string          `json:"custom_payload"`
-	DecodedCustomPayload  *json.RawMessage `json:"decoded_custom_payload"`
+	DecodedCustomPayload  *json.RawMessage `json:"decoded_custom_payload" swaggertype:"object"`
 	ForwardAmount         *string          `json:"forward_amount"`
 	ForwardPayload        *string          `json:"forward_payload"`
-	DecodedForwardPayload *json.RawMessage `json:"decoded_forward_payload"`
+	DecodedForwardPayload *json.RawMessage `json:"decoded_forward_payload" swaggertype:"object"`
 	TraceId               *HashType        `json:"trace_id"`
 } // @name NFTTransfer
 
@@ -415,10 +415,10 @@ type JettonTransfer struct {
 	TransactionAborted    bool             `json:"transaction_aborted"`
 	ResponseDestination   *AccountAddress  `json:"response_destination"`
 	CustomPayload         *string          `json:"custom_payload"`
-	DecodedCustomPayload  *json.RawMessage `json:"decoded_custom_payload"`
+	DecodedCustomPayload  *json.RawMessage `json:"decoded_custom_payload" swaggertype:"object"`
 	ForwardTonAmount      *string          `json:"forward_ton_amount"`
 	ForwardPayload        *string          `json:"forward_payload"`
-	DecodedForwardPayload *json.RawMessage `json:"decoded_forward_payload"`
+	DecodedForwardPayload *json.RawMessage `json:"decoded_forward_payload" swaggertype:"object"`
 	TraceId               *HashType        `json:"trace_id"`
 } // @name JettonTransfer
 
@@ -434,7 +434,7 @@ type JettonBurn struct {
 	Amount               string           `json:"amount"`
 	ResponseDestination  *AccountAddress  `json:"response_destination"`
 	CustomPayload        *string          `json:"custom_payload"`
-	DecodedCustomPayload *json.RawMessage `json:"decoded_custom_payload"`
+	DecodedCustomPayload *json.RawMessage `json:"decoded_custom_payload" swaggertype:"object"`
 	TraceId              *HashType        `json:"trace_id"`
 } // @name JettonBurn
 


### PR DESCRIPTION
I've added the swaggertype:"object" tag to all the json.RawMessage fields in:
- NFTTransfer struct
- JettonTransfer struct
- JettonBurn struct