### PR TITLE
Fix swallowed exception in try_classify_basic_actions fallback

### DIFF
--- a/indexer/indexer/events/event_processing.py
+++ b/indexer/indexer/events/event_processing.py
@@ -403,6 +403,8 @@ async def try_classify_basic_actions(trace: Trace) -> list[Action]:
             blocks = await post_processor(blocks)
         actions, _ = serialize_blocks(blocks, trace_id=trace.trace_id, trace=trace)
         return actions
-    except Exception as e:
-        logging.error(f"Failed trace classification fallback for {trace.trace_id}:", e)
+    except Exception:
+        logging.exception(
+            "Failed trace classification fallback for %s", trace.trace_id
+        )
         return []


### PR DESCRIPTION
## Problem

In `indexer/indexer/events/event_processing.py`, the fallback path of `try_classify_basic_actions` swallows the underlying exception:

```python
except Exception as e:
    logging.error(f"Failed trace classification fallback for {trace.trace_id}:", e)
    return []
```

`logging.error` has the signature `error(msg, *args, **kwargs)` and treats positional args as printf-style substitutions. The format string contains no `%s`, so `e` is silently dropped — only the generic message is logged, never the exception class, message, or traceback.

In production this means: when basic classification fails as the *last-chance fallback* for a trace, operators see only `Failed trace classification fallback for <id>:` in logs with no information about why. Diagnosing recurring failures becomes very hard.

## Fix

Use `logging.exception`, which captures the active exception with traceback, and pass `trace_id` via `%s` substitution. The `except` clause no longer needs to bind `e`.

```python
except Exception:
    logging.exception(
        "Failed trace classification fallback for %s", trace.trace_id
    )
    return []
```

## Scope

- Single file, single function, +4 / −2 lines.
- No behavioral change — same exception is still caught, same `[]` is still returned. Only the log output changes (gains traceback + exception type).
- No public API or schema impact.