### PR TITLE
Fix swallowed exception in try_classify_unknown_trace fallback

### DIFF
--- a/indexer/indexer/events/event_processing.py
+++ b/indexer/indexer/events/event_processing.py
@@ -381,8 +381,11 @@ async def try_classify_unknown_trace(trace):
         if len(actions) == 0:
             unknown_action = create_unknown_action(trace)
             actions.append(unknown_action)
-    except Exception as e:
-        logging.error(f"Failed to classify trace {trace.trace_id}. Falling back to unknown action")
+    except Exception:
+        logging.exception(
+            "Failed to classify trace %s. Falling back to unknown action",
+            trace.trace_id,
+        )
         unknown_action = create_unknown_action(trace)
         actions.append(unknown_action)
     return actions


### PR DESCRIPTION
## Problem

In `indexer/indexer/events/event_processing.py`, the fallback path of `try_classify_unknown_trace` binds the exception but never uses it:

```python
except Exception as e:
    logging.error(f"Failed to classify trace {trace.trace_id}. Falling back to unknown action")
    unknown_action = create_unknown_action(trace)
    actions.append(unknown_action)
```

`e` is bound but dropped. When classification fails and the trace falls back to an `unknown_action`, operators see only the generic message in logs — no exception class, no message, no traceback. Diagnosing recurring classification failures becomes very hard.

This is the same anti-pattern fixed for the sibling `try_classify_basic_actions` in #384. Applying the same fix here keeps the two fallback paths consistent.

## Fix

Use `logging.exception`, which captures the active exception with traceback, and pass `trace_id` via `%s` substitution. The `except` clause no longer needs to bind `e`.

```python
except Exception:
    logging.exception(
        "Failed to classify trace %s. Falling back to unknown action",
        trace.trace_id,
    )
    unknown_action = create_unknown_action(trace)
    actions.append(unknown_action)
```

## Scope

- Single file, single function, +5 / −2 lines.
- No behavioral change — same exception is still caught, same `unknown_action` is still appended. Only the log output changes (gains traceback + exception type).
- No public API or schema impact.