### PR TITLE
Fix logging issues in process_event_async exception handler

### DIFF
--- a/indexer/indexer/events/event_processing.py
+++ b/indexer/indexer/events/event_processing.py
@@ -323,10 +323,9 @@ async def process_event_async(trace: Trace) -> Block:
         return root
     except NoMessageBodyException as e:
         raise e
-    except Exception as e:
-        logging.error(f"Failed to process {trace.trace_id}")
-        logging.exception(e, exc_info=True)
-        raise e
+    except Exception:
+        logging.exception("Failed to process %s", trace.trace_id)
+        raise
 
 async def process_event_async_with_postprocessing(trace: Trace) -> list[Block]:
     block = await process_event_async(trace)


### PR DESCRIPTION
## Problem

In `indexer/indexer/events/event_processing.py`, the `Exception` handler of `process_event_async` has three compounded issues in four lines:

```python
except Exception as e:
    logging.error(f"Failed to process {trace.trace_id}")
    logging.exception(e, exc_info=True)
    raise e
```

1. **`logging.exception(e, exc_info=True)` passes the exception as the format string.** `logging.exception(msg, *args, **kwargs)` treats its first argument as a printf-style format string. If `str(e)` ever contains a literal `%`, the formatter raises `TypeError` inside the error handler — masking the underlying exception with a logging failure.

2. **`exc_info=True` is redundant.** `logging.exception` always implies `exc_info=True`; that is its only difference from `logging.error`.

3. **Double-logging.** Every failure emits two records (`logging.error` then `logging.exception`), inflating log volume and splitting correlated context across two records.

A separate concern, cheap to fix in the same patch: `raise e` re-raises the bound name rather than the active exception, which can obscure the original traceback in some tooling and is flagged by Ruff B904. Bare `raise` re-raises the active exception, preserving the full traceback.

## Fix

Consolidate to a single `logging.exception` call with `%s` substitution, and use bare `raise`. The `except` clause no longer needs to bind `e`.

```python
except Exception:
    logging.exception("Failed to process %s", trace.trace_id)
    raise
```

The exception's class, message, and traceback are now captured exactly once, in one record, without depending on `str(e)` being printf-safe.

## Scope

- Single file, single function, +3 / −4 lines.
- No behavioral change — same exception is still caught, same re-raise semantics (caller still gets the active exception).
- Log output: from two records (one carrying a printf-format risk) to a single record with proper traceback and `%s`-substituted trace_id.
- No public API or schema impact.