### PR TITLE
Capture full traceback in try_process_unknown_event exception handler

### DIFF
--- a/indexer/indexer/events/event_processing.py
+++ b/indexer/indexer/events/event_processing.py
@@ -360,9 +360,9 @@ async def try_process_unknown_event(trace: Trace) -> list[Block]:
         for post_processor in trace_post_processors:
             blocks = await post_processor(blocks)
         return blocks
-    except Exception as e:
-        logging.error(f"Failed to process {trace.trace_id}: {e}" )
-        raise e
+    except Exception:
+        logging.exception("Failed to process %s", trace.trace_id)
+        raise
 
 async def try_classify_unknown_trace(trace):
     actions = []


### PR DESCRIPTION
## Problem

In `indexer/indexer/events/event_processing.py`, the `Exception` handler of `try_process_unknown_event` logs only `str(e)` and re-raises with `raise e`:

```python
except Exception as e:
    logging.error(f"Failed to process {trace.trace_id}: {e}" )
    raise e
```

Two issues:

1. **No traceback captured at this layer.** The log records only the trace_id and `str(e)`. When the failure is investigated from this log line, there is no frame information about *where* the failure originated inside the matchers / serializers / post-processors invoked above. The caller does see the exception (re-raised), but a local log without traceback is hard to act on in isolation.

2. **`raise e` instead of bare `raise`.** This re-raises the bound name rather than the active exception, which can obscure the original traceback in some tooling and is flagged by Ruff B904.

This is the same family of fixes as #384 (and #385, #386 on sibling handlers in this file): use `logging.exception` to capture the traceback and bare `raise` to preserve frame info.

## Fix

Switch to `logging.exception` with `%s` substitution and use bare `raise`. The `except` clause no longer needs to bind `e`.

```python
except Exception:
    logging.exception("Failed to process %s", trace.trace_id)
    raise
```

## Scope

- Single file, single function, +3 / −3 lines.
- No behavioral change — same exception is still caught, same re-raise semantics (caller still gets the active exception).
- Log output: gains traceback + exception type; loses the inline `str(e)` from the message line, but `logging.exception` includes the exception class and message at the end of the traceback, so no information is lost.
- No public API or schema impact.