### PR TITLE
ton-trace-emulator improvements

### DIFF
--- a/ansible/systemd.service.j2
+++ b/ansible/systemd.service.j2
@@ -10,6 +10,7 @@ ExecStart={{ start_cmd }}
 ExecStopPost = /bin/echo "{{ service_name }} service down"
 User = {{ service.service_user | default("root") }}
 Group = {{ service.service_group | default("root") }}
+LogRateLimitIntervalSec=0
 {% if service.environment is defined %}
 {% if service.environment is string %}
 Environment="{{ service.environment }}"

--- a/deploy-pendings.yaml
+++ b/deploy-pendings.yaml
@@ -133,6 +133,7 @@
           - libsecp256k1-dev
           - libsodium-dev
           - libhiredis-dev
+          - redis-tools
         state: present
 
     - name: Copy binaries
@@ -209,6 +210,33 @@
         name: redis-server
         state: restarted
       when: redis_maxclients_config.changed
+
+    - name: Stop pendings services before Redis flush
+      ansible.builtin.systemd:
+        name: "{{ service_name }}"
+        state: stopped
+        daemon_reload: true
+      vars:
+        service_name: "{{ stack_name }}__{{ item }}"
+      throttle: 1
+      with_items:
+       - trace_emulator
+       - pendings_action_classifier
+       - trace_ttl_tracker
+
+    - name: Flush pendings Redis database
+      ansible.builtin.command:
+        argv:
+          - redis-cli
+          - -h
+          - "127.0.0.1"
+          - -p
+          - "6379"
+          - FLUSHDB
+      environment:
+        REDISCLI_AUTH: "{{ pendings_redis_password }}"
+      changed_when: true
+      no_log: true
 
     - name: Restart and enable pendings services
       ansible.builtin.systemd:

--- a/ton-index-worker/CMakeLists.txt
+++ b/ton-index-worker/CMakeLists.txt
@@ -25,7 +25,18 @@ add_subdirectory(external/ton EXCLUDE_FROM_ALL)
 add_subdirectory(external/libpqxx EXCLUDE_FROM_ALL)
 add_subdirectory(external/clickhouse-cpp EXCLUDE_FROM_ALL)
 set(REDIS_PLUS_PLUS_BUILD_TEST OFF CACHE BOOL "disable test" FORCE)
+
+# workaround to link static libhiredis
+set(TON_INDEXER_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
+set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+find_library(TON_INDEXER_HIREDIS_STATIC_LIB hiredis REQUIRED)
+set(CMAKE_FIND_LIBRARY_SUFFIXES ${TON_INDEXER_CMAKE_FIND_LIBRARY_SUFFIXES})
+unset(TON_INDEXER_CMAKE_FIND_LIBRARY_SUFFIXES)
+set(HIREDIS_LIB "${TON_INDEXER_HIREDIS_STATIC_LIB}" CACHE FILEPATH "hiredis static library" FORCE)
+set(REDIS_PLUS_PLUS_BUILD_SHARED OFF CACHE BOOL "disable shared redis++" FORCE)
 add_subdirectory(external/redis-plus-plus EXCLUDE_FROM_ALL)
+target_link_libraries(redis++_static PUBLIC ${TON_INDEXER_HIREDIS_STATIC_LIB})
+
 set(MSGPACK_USE_BOOST OFF CACHE BOOL "disable boost" FORCE)
 set(MSGPACK_USE_STD_VARIANT_ADAPTOR ON CACHE BOOL "enable std::variant" FORCE)
 add_subdirectory(external/msgpack-c EXCLUDE_FROM_ALL)

--- a/ton-index-worker/ton-trace-emulator/CMakeLists.txt
+++ b/ton-index-worker/ton-trace-emulator/CMakeLists.txt
@@ -41,6 +41,6 @@ target_include_directories(ton-trace-emulator
 )
 target_compile_features(ton-trace-emulator PRIVATE cxx_std_20)
 target_compile_definitions(ton-trace-emulator PRIVATE -DMSGPACK_USE_DEFINE_MAP)
-target_link_libraries(ton-trace-emulator ton-trace-emulator-core hiredis redis++_static msgpack-cxx)
+target_link_libraries(ton-trace-emulator ton-trace-emulator-core redis++_static msgpack-cxx)
 target_link_options(ton-trace-emulator PUBLIC -rdynamic)
 install(TARGETS ton-trace-emulator RUNTIME DESTINATION bin)

--- a/ton-index-worker/ton-trace-emulator/CMakeLists.txt
+++ b/ton-index-worker/ton-trace-emulator/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 add_library(ton-trace-emulator-core STATIC
     src/TraceEmulator.cpp
+    src/ExternalMessageAdmission.cpp
     src/OverlayListener.cpp
     src/BlockEmulator.cpp
     src/TraceInterfaceDetector.cpp

--- a/ton-index-worker/ton-trace-emulator/src/BlockEmulator.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/BlockEmulator.cpp
@@ -31,31 +31,6 @@ InterblockTraceStore& interblock_trace_store() {
   static InterblockTraceStore store;
   return store;
 }
-
-void set_read_block_attribute(const std::shared_ptr<OtelStageSpan>& span,
-                              const std::string& key,
-                              std::int64_t value) {
-    if (span) {
-        span->set_attribute(key, value);
-    }
-}
-
-void finish_read_block_span(std::shared_ptr<OtelStageSpan>& span) {
-    if (!span) {
-        return;
-    }
-    span->end();
-    span.reset();
-}
-
-void fail_read_block_span(std::shared_ptr<OtelStageSpan>& span, const std::string& error_type, const td::Status& error) {
-    if (!span) {
-        return;
-    }
-    span->mark_error(error_type, error.to_string());
-    span->end();
-    span.reset();
-}
 }  // namespace
 
 
@@ -174,12 +149,10 @@ public:
 
 McBlockEmulator::McBlockEmulator(schema::MasterchainBlockDataState mc_data_state,
                                  std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
-                                 td::Promise<> promise,
-                                 std::shared_ptr<OtelStageSpan> read_block_span)
+                                 td::Promise<> promise)
     : mc_data_state_(std::move(mc_data_state)),
       trace_processor_(std::move(trace_processor)),
       promise_(std::move(promise)),
-      read_block_span_(std::move(read_block_span)),
       blocks_left_to_parse_(mc_data_state_.shard_blocks_diff_.size()) {
 }
 
@@ -209,7 +182,6 @@ void McBlockEmulator::start_up() {
 
 void McBlockEmulator::parse_error(ton::BlockId blkid, td::Status error, MeasurementPtr) {
     LOG(ERROR) << "Failed to parse block " << blkid.to_str() << ": " << error;
-    fail_read_block_span(read_block_span_, "trace_emulator.read_block_error", error);
     promise_.set_error(std::move(error));
     stop();
 }
@@ -256,10 +228,6 @@ void McBlockEmulator::process_txs(MeasurementPtr measurement) {
         }
         tx_by_in_msg_hash_.insert({tx.in_msg_hash, tx});
     }
-    set_read_block_attribute(read_block_span_, "ton.block.parsed_blocks_count", static_cast<std::int64_t>(mc_data_state_.shard_blocks_diff_.size()));
-    set_read_block_attribute(read_block_span_, "ton.block.shards_count", static_cast<std::int64_t>(mc_data_state_.shard_blocks_.size()));
-    set_read_block_attribute(read_block_span_, "ton.block.transactions_count", static_cast<std::int64_t>(txs_.size()));
-    finish_read_block_span(read_block_span_);
     emulate_traces(measurement);
 }
 
@@ -486,7 +454,6 @@ void ConfirmedBlockEmulator::start_up() {
 
 void ConfirmedBlockEmulator::parse_error(td::Status error, MeasurementPtr) {
     LOG(ERROR) << "Failed to parse " << finality_label() << " block " << block_data_state_.block_data->block_id().to_str() << ": " << error;
-    fail_read_block_span(read_block_span_, "trace_emulator.read_block_error", error);
     promise_.set_error(std::move(error));
     stop();
 }
@@ -529,10 +496,6 @@ void ConfirmedBlockEmulator::process_txs(MeasurementPtr measurement) {
         }
         tx_by_in_msg_hash_.insert({tx.in_msg_hash, tx});
     }
-    set_read_block_attribute(read_block_span_, "ton.block.parsed_blocks_count", static_cast<std::int64_t>(1));
-    set_read_block_attribute(read_block_span_, "ton.block.shards_count", static_cast<std::int64_t>(shard_states_snapshot_.size()));
-    set_read_block_attribute(read_block_span_, "ton.block.transactions_count", static_cast<std::int64_t>(txs_.size()));
-    finish_read_block_span(read_block_span_);
     emulate_traces(measurement);
 }
 

--- a/ton-index-worker/ton-trace-emulator/src/BlockEmulator.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/BlockEmulator.cpp
@@ -1,5 +1,6 @@
 #include "BlockEmulator.h"
 #include "TraceInterfaceDetector.h"
+#include <cstdint>
 #include <mutex>
 #include <unordered_map>
 
@@ -29,6 +30,31 @@ class InterblockTraceStore {
 InterblockTraceStore& interblock_trace_store() {
   static InterblockTraceStore store;
   return store;
+}
+
+void set_read_block_attribute(const std::shared_ptr<OtelStageSpan>& span,
+                              const std::string& key,
+                              std::int64_t value) {
+    if (span) {
+        span->set_attribute(key, value);
+    }
+}
+
+void finish_read_block_span(std::shared_ptr<OtelStageSpan>& span) {
+    if (!span) {
+        return;
+    }
+    span->end();
+    span.reset();
+}
+
+void fail_read_block_span(std::shared_ptr<OtelStageSpan>& span, const std::string& error_type, const td::Status& error) {
+    if (!span) {
+        return;
+    }
+    span->mark_error(error_type, error.to_string());
+    span->end();
+    span.reset();
 }
 }  // namespace
 
@@ -146,9 +172,15 @@ public:
     }
 };
 
-McBlockEmulator::McBlockEmulator(schema::MasterchainBlockDataState mc_data_state, std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor, td::Promise<> promise)
-        : mc_data_state_(std::move(mc_data_state)), trace_processor_(std::move(trace_processor)), promise_(std::move(promise)), 
-          blocks_left_to_parse_(mc_data_state_.shard_blocks_diff_.size()) {
+McBlockEmulator::McBlockEmulator(schema::MasterchainBlockDataState mc_data_state,
+                                 std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
+                                 td::Promise<> promise,
+                                 std::shared_ptr<OtelStageSpan> read_block_span)
+    : mc_data_state_(std::move(mc_data_state)),
+      trace_processor_(std::move(trace_processor)),
+      promise_(std::move(promise)),
+      read_block_span_(std::move(read_block_span)),
+      blocks_left_to_parse_(mc_data_state_.shard_blocks_diff_.size()) {
 }
 
 void McBlockEmulator::start_up() {
@@ -177,6 +209,7 @@ void McBlockEmulator::start_up() {
 
 void McBlockEmulator::parse_error(ton::BlockId blkid, td::Status error, MeasurementPtr) {
     LOG(ERROR) << "Failed to parse block " << blkid.to_str() << ": " << error;
+    fail_read_block_span(read_block_span_, "trace_emulator.read_block_error", error);
     promise_.set_error(std::move(error));
     stop();
 }
@@ -221,9 +254,12 @@ void McBlockEmulator::process_txs(MeasurementPtr measurement) {
                 interblock_trace_store().put(out_msg.hash, tx.trace_ids.value());
             }
         }
-
         tx_by_in_msg_hash_.insert({tx.in_msg_hash, tx});
     }
+    set_read_block_attribute(read_block_span_, "ton.block.parsed_blocks_count", static_cast<std::int64_t>(mc_data_state_.shard_blocks_diff_.size()));
+    set_read_block_attribute(read_block_span_, "ton.block.shards_count", static_cast<std::int64_t>(mc_data_state_.shard_blocks_.size()));
+    set_read_block_attribute(read_block_span_, "ton.block.transactions_count", static_cast<std::int64_t>(txs_.size()));
+    finish_read_block_span(read_block_span_);
     emulate_traces(measurement);
 }
 
@@ -281,8 +317,14 @@ void McBlockEmulator::emulate_traces(MeasurementPtr measurement) {
 
         in_progress_cnt_++;
 
+        tx_measurement->set_ext_msg_hash(tx.trace_ids->ext_in_msg_hash);
+        tx_measurement->set_ext_msg_hash_norm(tx.trace_ids->ext_in_msg_hash_norm);
+        tx_measurement->set_trace_root_tx_hash(tx.trace_ids->root_tx_hash);
+        tx_measurement->start_otel_child_span("build_trace_tree");
         std::vector<EmuRequest> reqs;
         auto parent_node = construct_commited_trace(tx, reqs, tx_measurement);
+        tx_measurement->set_otel_attribute("ton.trace.tail_requests_count", static_cast<std::int64_t>(reqs.size()));
+        tx_measurement->end_otel_child_span("build_trace_tree");
 
         if (reqs.empty()) {
             children_emulated(std::move(parent_node), {}, tx.trace_ids.value(), /*reqs*/{}, nullptr, tx_measurement);
@@ -306,21 +348,21 @@ void McBlockEmulator::emulate_traces(MeasurementPtr measurement) {
             msgs_to_emulate.push_back(EmulationMessage{r.msg, r.depth});
         }
 
+        tx_measurement->start_otel_child_span("emulate_tail");
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this),
-                                            parent_node = std::move(parent_node),
-                                            tx_info = tx,
-                                            context = std::move(context),
-                                            reqs = std::move(reqs),
-                                            tx_measurement]
-            (td::Result<std::vector<std::unique_ptr<TraceNode>>> R) mutable {
-                if (R.is_error()) {
-                    td::actor::send_closure(SelfId, &McBlockEmulator::trace_error,
-                        tx_info.hash, tx_info.trace_ids->root_tx_hash, R.move_as_error(), tx_measurement);
-                } else {
-                    td::actor::send_closure(SelfId, &McBlockEmulator::children_emulated,
-                        std::move(parent_node), R.move_as_ok(), tx_info.trace_ids.value(),
-                        std::move(reqs), std::move(context), tx_measurement);
-                }
+                                             parent_node = std::move(parent_node),
+                                             tx_info = tx,
+                                             context = std::move(context),
+                                             reqs = std::move(reqs),
+                                             tx_measurement](td::Result<std::vector<std::unique_ptr<TraceNode>>> R) mutable {
+            if (R.is_error()) {
+                td::actor::send_closure(SelfId, &McBlockEmulator::trace_error,
+                    tx_info.hash, tx_info.trace_ids->root_tx_hash, R.move_as_error(), tx_measurement);
+            } else {
+                td::actor::send_closure(SelfId, &McBlockEmulator::children_emulated,
+                    std::move(parent_node), R.move_as_ok(), tx_info.trace_ids.value(),
+                    std::move(reqs), std::move(context), tx_measurement);
+            }
         });
 
         td::actor::create_actor<MasterchainBlockEmulator>("MasterchainBlockEmulator", context_ref, std::move(msgs_to_emulate), std::move(P), tx_measurement).release();
@@ -350,12 +392,15 @@ void McBlockEmulator::children_emulated(std::unique_ptr<TraceNode> parent_node,
     measurement->set_trace_root_tx_hash(trace.root_tx_hash);
     measurement->set_transactions_count(trace.transactions_count());
     measurement->set_emulated_transactions_count(trace.root ? trace.root->emulated_transactions_count() : 0);
+    measurement->set_otel_attribute("ton.trace.depth", static_cast<std::int64_t>(trace.depth()));
 
     if (context) {
         trace.rand_seed = context->get_rand_seed();
         trace.emulated_accounts = context->release_account_states();
         trace.tx_limit_exceeded = context->is_limit_exceeded();
     }
+    measurement->set_otel_attribute("ton.trace.tx_limit_exceeded", trace.tx_limit_exceeded);
+    measurement->end_otel_child_span("emulate_tail");
 
     if constexpr (std::variant_size_v<Trace::Detector::DetectedInterface> > 0) {
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), trace_root_tx_hash = trace.root_tx_hash, measurement](td::Result<Trace> R) {
@@ -366,6 +411,7 @@ void McBlockEmulator::children_emulated(std::unique_ptr<TraceNode> parent_node,
             td::actor::send_closure(SelfId, &McBlockEmulator::trace_emulated, R.move_as_ok(), measurement);
         });
 
+        measurement->start_otel_child_span("detect_interfaces");
         td::actor::create_actor<TraceInterfaceDetector>("TraceInterfaceDetector", shard_states_, mc_data_state_.config_, std::move(trace), std::move(P), measurement).release();
     } else {
         trace_emulated(std::move(trace), measurement);
@@ -375,6 +421,7 @@ void McBlockEmulator::children_emulated(std::unique_ptr<TraceNode> parent_node,
 void McBlockEmulator::trace_error(td::Bits256 tx_hash, td::Bits256 trace_root_tx_hash, td::Status error, MeasurementPtr measurement) {
     LOG(ERROR) << "Failed to emulate trace with root tx " << td::base64_encode(trace_root_tx_hash.as_slice()) << " from tx " << tx_hash.to_hex() << ": " << error;
     measurement->mark_otel_error("trace_emulator.processing_error", error.to_string());
+    measurement->end_otel_child_span("emulate_tail");
     in_progress_cnt_--;
     measurement->emit_otel_span();
 }
@@ -382,11 +429,14 @@ void McBlockEmulator::trace_error(td::Bits256 tx_hash, td::Bits256 trace_root_tx
 void McBlockEmulator::trace_interfaces_error(td::Bits256 trace_root_tx_hash, td::Status error, MeasurementPtr measurement) {
     LOG(ERROR) << "Failed to detect interfaces on trace with root tx " << td::base64_encode(trace_root_tx_hash.as_slice()) << ": " << error;
     measurement->mark_otel_error("trace_emulator.interface_error", error.to_string());
+    measurement->end_otel_child_span("detect_interfaces");
     in_progress_cnt_--;
     measurement->emit_otel_span();
 }
 
 void McBlockEmulator::trace_emulated(Trace trace, MeasurementPtr measurement) {
+    measurement->end_otel_child_span("detect_interfaces");
+    measurement->start_otel_child_span("insert_trace");
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), trace_root_tx_hash = trace.root_tx_hash, measurement](td::Result<td::Unit> R) {
         if (R.is_error()) {
             auto error = R.move_as_error();
@@ -395,6 +445,7 @@ void McBlockEmulator::trace_emulated(Trace trace, MeasurementPtr measurement) {
         } else {
             LOG(DEBUG) << "Successfully inserted trace " << td::base64_encode(trace_root_tx_hash.as_slice());
         }
+        measurement->end_otel_child_span("insert_trace");
         td::actor::send_closure(SelfId, &McBlockEmulator::trace_finished, trace_root_tx_hash, measurement);
     });
     trace_processor_(std::move(trace), std::move(P), measurement);
@@ -435,6 +486,7 @@ void ConfirmedBlockEmulator::start_up() {
 
 void ConfirmedBlockEmulator::parse_error(td::Status error, MeasurementPtr) {
     LOG(ERROR) << "Failed to parse " << finality_label() << " block " << block_data_state_.block_data->block_id().to_str() << ": " << error;
+    fail_read_block_span(read_block_span_, "trace_emulator.read_block_error", error);
     promise_.set_error(std::move(error));
     stop();
 }
@@ -475,9 +527,12 @@ void ConfirmedBlockEmulator::process_txs(MeasurementPtr measurement) {
                 interblock_trace_store().put(out_msg.hash, tx.trace_ids.value());
             }
         }
-
         tx_by_in_msg_hash_.insert({tx.in_msg_hash, tx});
     }
+    set_read_block_attribute(read_block_span_, "ton.block.parsed_blocks_count", static_cast<std::int64_t>(1));
+    set_read_block_attribute(read_block_span_, "ton.block.shards_count", static_cast<std::int64_t>(shard_states_snapshot_.size()));
+    set_read_block_attribute(read_block_span_, "ton.block.transactions_count", static_cast<std::int64_t>(txs_.size()));
+    finish_read_block_span(read_block_span_);
     emulate_traces(measurement);
 }
 
@@ -494,8 +549,14 @@ void ConfirmedBlockEmulator::emulate_traces(MeasurementPtr measurement) {
 
         in_progress_cnt_++;
 
+        tx_measurement->set_ext_msg_hash(tx.trace_ids->ext_in_msg_hash);
+        tx_measurement->set_ext_msg_hash_norm(tx.trace_ids->ext_in_msg_hash_norm);
+        tx_measurement->set_trace_root_tx_hash(tx.trace_ids->root_tx_hash);
+        tx_measurement->start_otel_child_span("build_trace_tree");
         std::vector<EmuRequest> reqs;
         auto parent_node = construct_confirmed_trace(tx, reqs, tx_measurement);
+        tx_measurement->set_otel_attribute("ton.trace.tail_requests_count", static_cast<std::int64_t>(reqs.size()));
+        tx_measurement->end_otel_child_span("build_trace_tree");
 
         if (reqs.empty()) {
             children_emulated(std::move(parent_node), {}, tx.trace_ids.value(), {}, nullptr, tx_measurement);
@@ -522,6 +583,7 @@ void ConfirmedBlockEmulator::emulate_traces(MeasurementPtr measurement) {
             msgs_to_emulate.push_back(EmulationMessage{r.msg, r.depth});
         }
 
+        tx_measurement->start_otel_child_span("emulate_tail");
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this),
                                              parent_node = std::move(parent_node),
                                              tx_info = tx,
@@ -613,12 +675,15 @@ void ConfirmedBlockEmulator::children_emulated(std::unique_ptr<TraceNode> parent
     measurement->set_trace_root_tx_hash(trace.root_tx_hash);
     measurement->set_transactions_count(trace.transactions_count());
     measurement->set_emulated_transactions_count(trace.root ? trace.root->emulated_transactions_count() : 0);
+    measurement->set_otel_attribute("ton.trace.depth", static_cast<std::int64_t>(trace.depth()));
 
     if (context) {
         trace.rand_seed = context->get_rand_seed();
         trace.emulated_accounts = context->release_account_states();
         trace.tx_limit_exceeded = context->is_limit_exceeded();
     }
+    measurement->set_otel_attribute("ton.trace.tx_limit_exceeded", trace.tx_limit_exceeded);
+    measurement->end_otel_child_span("emulate_tail");
 
     if constexpr (std::variant_size_v<Trace::Detector::DetectedInterface> > 0) {
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), trace_root_tx_hash = trace.root_tx_hash, measurement](td::Result<Trace> R) {
@@ -635,6 +700,7 @@ void ConfirmedBlockEmulator::children_emulated(std::unique_ptr<TraceNode> parent
             shard_states.push_back(snapshot.state);
         }
 
+        measurement->start_otel_child_span("detect_interfaces");
         td::actor::create_actor<TraceInterfaceDetector>("ConfirmedTraceInterfaceDetector",
                                                         shard_states, config_, std::move(trace), std::move(P), measurement).release();
     } else {
@@ -646,6 +712,7 @@ void ConfirmedBlockEmulator::trace_error(td::Bits256 tx_hash, td::Bits256 trace_
     LOG(ERROR) << "Failed to emulate " << finality_label() << " trace with root tx " << td::base64_encode(trace_root_tx_hash.as_slice())
                << " from tx " << tx_hash.to_hex() << ": " << error;
     measurement->mark_otel_error("trace_emulator.processing_error", error.to_string());
+    measurement->end_otel_child_span("emulate_tail");
     trace_finished(trace_root_tx_hash, measurement);
 }
 
@@ -653,10 +720,13 @@ void ConfirmedBlockEmulator::trace_interfaces_error(td::Bits256 trace_root_tx_ha
     LOG(ERROR) << "Failed to detect interfaces on " << finality_label() << " trace with root tx "
                << td::base64_encode(trace_root_tx_hash.as_slice()) << ": " << error;
     measurement->mark_otel_error("trace_emulator.interface_error", error.to_string());
+    measurement->end_otel_child_span("detect_interfaces");
     trace_finished(trace_root_tx_hash, measurement);
 }
 
 void ConfirmedBlockEmulator::trace_emulated(Trace trace, MeasurementPtr measurement) {
+    measurement->end_otel_child_span("detect_interfaces");
+    measurement->start_otel_child_span("insert_trace");
     auto root_hash = trace.root_tx_hash;
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), root_hash, label = std::string(finality_label()), measurement](td::Result<td::Unit> R) {
         if (R.is_error()) {
@@ -666,6 +736,7 @@ void ConfirmedBlockEmulator::trace_emulated(Trace trace, MeasurementPtr measurem
         } else {
             LOG(DEBUG) << "Inserted " << label << " trace " << td::base64_encode(root_hash.as_slice());
         }
+        measurement->end_otel_child_span("insert_trace");
         td::actor::send_closure(SelfId, &ConfirmedBlockEmulator::trace_finished, root_hash, measurement);
     });
 

--- a/ton-index-worker/ton-trace-emulator/src/BlockEmulator.h
+++ b/ton-index-worker/ton-trace-emulator/src/BlockEmulator.h
@@ -49,6 +49,7 @@ private:
     schema::MasterchainBlockDataState mc_data_state_;
     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor_;
     td::Promise<> promise_;
+    std::shared_ptr<OtelStageSpan> read_block_span_;
     size_t blocks_left_to_parse_;
     std::vector<TransactionInfo> txs_;
 
@@ -81,7 +82,10 @@ private:
     void trace_finished(td::Bits256, MeasurementPtr measurement);
 
 public:
-    McBlockEmulator(schema::MasterchainBlockDataState mc_data_state, std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor, td::Promise<> promise);
+    McBlockEmulator(schema::MasterchainBlockDataState mc_data_state,
+                    std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
+                    td::Promise<> promise,
+                    std::shared_ptr<OtelStageSpan> read_block_span = nullptr);
 
     virtual void start_up() override;
 };
@@ -94,6 +98,7 @@ private:
     std::vector<ShardStateSnapshot> shard_states_snapshot_;
     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor_;
     td::Promise<> promise_;
+    std::shared_ptr<OtelStageSpan> read_block_span_;
     std::vector<TransactionInfo> txs_;
     std::unordered_map<td::Bits256, TransactionInfo> tx_by_in_msg_hash_;
     std::unordered_map<td::Bits256, TransactionInfo> tx_by_out_msg_hash_;
@@ -136,11 +141,13 @@ public:
                            std::shared_ptr<block::ConfigInfo> config,
                            std::vector<ShardStateSnapshot> shard_states_snapshot,
                            std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
-                           td::Promise<> promise)
+                           td::Promise<> promise,
+                           std::shared_ptr<OtelStageSpan> read_block_span = nullptr)
         : finality_(finality),
           block_data_state_(std::move(block_data_state)),
           config_(std::move(config)),
           shard_states_snapshot_(std::move(shard_states_snapshot)),
           trace_processor_(std::move(trace_processor)),
-          promise_(std::move(promise)) {}
+          promise_(std::move(promise)),
+          read_block_span_(std::move(read_block_span)) {}
 };

--- a/ton-index-worker/ton-trace-emulator/src/BlockEmulator.h
+++ b/ton-index-worker/ton-trace-emulator/src/BlockEmulator.h
@@ -49,7 +49,6 @@ private:
     schema::MasterchainBlockDataState mc_data_state_;
     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor_;
     td::Promise<> promise_;
-    std::shared_ptr<OtelStageSpan> read_block_span_;
     size_t blocks_left_to_parse_;
     std::vector<TransactionInfo> txs_;
 
@@ -84,8 +83,7 @@ private:
 public:
     McBlockEmulator(schema::MasterchainBlockDataState mc_data_state,
                     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
-                    td::Promise<> promise,
-                    std::shared_ptr<OtelStageSpan> read_block_span = nullptr);
+                    td::Promise<> promise);
 
     virtual void start_up() override;
 };
@@ -98,7 +96,6 @@ private:
     std::vector<ShardStateSnapshot> shard_states_snapshot_;
     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor_;
     td::Promise<> promise_;
-    std::shared_ptr<OtelStageSpan> read_block_span_;
     std::vector<TransactionInfo> txs_;
     std::unordered_map<td::Bits256, TransactionInfo> tx_by_in_msg_hash_;
     std::unordered_map<td::Bits256, TransactionInfo> tx_by_out_msg_hash_;
@@ -141,13 +138,11 @@ public:
                            std::shared_ptr<block::ConfigInfo> config,
                            std::vector<ShardStateSnapshot> shard_states_snapshot,
                            std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
-                           td::Promise<> promise,
-                           std::shared_ptr<OtelStageSpan> read_block_span = nullptr)
+                           td::Promise<> promise)
         : finality_(finality),
           block_data_state_(std::move(block_data_state)),
           config_(std::move(config)),
           shard_states_snapshot_(std::move(shard_states_snapshot)),
           trace_processor_(std::move(trace_processor)),
-          promise_(std::move(promise)),
-          read_block_span_(std::move(read_block_span)) {}
+          promise_(std::move(promise)) {}
 };

--- a/ton-index-worker/ton-trace-emulator/src/ExternalMessageAdmission.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/ExternalMessageAdmission.cpp
@@ -1,0 +1,95 @@
+#include "ExternalMessageAdmission.h"
+
+ExternalMessageAdmission::ExternalMessageAdmission(
+    std::size_t max_emulations_per_destination,
+    std::chrono::steady_clock::duration window)
+    : max_emulations_per_destination_(max_emulations_per_destination), window_(window) {
+}
+
+ExternalMessageAdmission::Result ExternalMessageAdmission::try_acquire(
+    const td::Bits256& msg_hash_norm, const block::StdAddress& destination) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    const auto now = Clock::now();
+    prune_locked(now);
+
+    if (known_messages_.find(msg_hash_norm) != known_messages_.end()) {
+        return {.accepted = false, .reject_reason = RejectReason::Duplicate};
+    }
+
+    auto& destination_window = destination_windows_[destination];
+    if (destination_window.size() >= max_emulations_per_destination_) {
+        return {
+            .accepted = false,
+            .reject_reason = RejectReason::DestinationRateLimit,
+            .accepted_for_destination = destination_window.size(),
+        };
+    }
+
+    known_messages_.emplace(msg_hash_norm, KnownMessage{now, true});
+    known_message_order_.emplace_back(now, msg_hash_norm);
+    destination_window.push_back(now);
+    destination_order_.emplace_back(now, destination);
+
+    return {
+        .accepted = true,
+        .reject_reason = RejectReason::None,
+        .accepted_for_destination = destination_window.size(),
+    };
+}
+
+void ExternalMessageAdmission::mark_emulated(const td::Bits256& msg_hash_norm) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = known_messages_.find(msg_hash_norm);
+    if (it == known_messages_.end()) {
+        return;
+    }
+
+    const auto now = Clock::now();
+    it->second = KnownMessage{now, false};
+    known_message_order_.emplace_back(now, msg_hash_norm);
+}
+
+void ExternalMessageAdmission::release_message(const td::Bits256& msg_hash_norm) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    known_messages_.erase(msg_hash_norm);
+}
+
+void ExternalMessageAdmission::prune_locked(TimePoint now) {
+    while (!known_message_order_.empty()) {
+        const auto& [timestamp, hash] = known_message_order_.front();
+        if (now - timestamp < window_) {
+            break;
+        }
+
+        auto it = known_messages_.find(hash);
+        if (it != known_messages_.end() && !it->second.in_progress && it->second.timestamp == timestamp) {
+            known_messages_.erase(it);
+        }
+        known_message_order_.pop_front();
+    }
+
+    while (!destination_order_.empty()) {
+        const auto& [timestamp, destination] = destination_order_.front();
+        if (now - timestamp < window_) {
+            break;
+        }
+
+        auto it = destination_windows_.find(destination);
+        if (it != destination_windows_.end()) {
+            auto& timestamps = it->second;
+            if (!timestamps.empty() && timestamps.front() == timestamp) {
+                timestamps.pop_front();
+            } else {
+                while (!timestamps.empty() && now - timestamps.front() >= window_) {
+                    timestamps.pop_front();
+                }
+            }
+            if (timestamps.empty()) {
+                destination_windows_.erase(it);
+            }
+        }
+
+        destination_order_.pop_front();
+    }
+}

--- a/ton-index-worker/ton-trace-emulator/src/ExternalMessageAdmission.h
+++ b/ton-index-worker/ton-trace-emulator/src/ExternalMessageAdmission.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+#include "IndexData.h"
+
+class ExternalMessageAdmission {
+public:
+    enum class RejectReason {
+        None,
+        Duplicate,
+        DestinationRateLimit,
+    };
+
+    struct Result {
+        bool accepted{false};
+        RejectReason reject_reason{RejectReason::None};
+        std::size_t accepted_for_destination{0};
+    };
+
+    static constexpr std::size_t kDefaultMaxEmulationsPerDestination = 3;
+    static constexpr std::int64_t kDefaultWindowSeconds = 10;
+
+    ExternalMessageAdmission(
+        std::size_t max_emulations_per_destination = kDefaultMaxEmulationsPerDestination,
+        std::chrono::steady_clock::duration window = std::chrono::seconds(kDefaultWindowSeconds));
+
+    Result try_acquire(const td::Bits256& msg_hash_norm, const block::StdAddress& destination);
+    void mark_emulated(const td::Bits256& msg_hash_norm);
+    void release_message(const td::Bits256& msg_hash_norm);
+
+private:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+
+    struct KnownMessage {
+        TimePoint timestamp;
+        bool in_progress{true};
+    };
+
+    void prune_locked(TimePoint now);
+
+    std::size_t max_emulations_per_destination_;
+    std::chrono::steady_clock::duration window_;
+
+    std::mutex mutex_;
+    std::unordered_map<td::Bits256, KnownMessage> known_messages_;
+    std::deque<std::pair<TimePoint, td::Bits256>> known_message_order_;
+    std::unordered_map<block::StdAddress, std::deque<TimePoint>> destination_windows_;
+    std::deque<std::pair<TimePoint, block::StdAddress>> destination_order_;
+};

--- a/ton-index-worker/ton-trace-emulator/src/Measurement.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/Measurement.cpp
@@ -68,7 +68,9 @@ Measurement::Measurement(const Measurement &other) {
     out_channel_ = other.out_channel_;
     error_type_ = other.error_type_;
     error_message_ = other.error_message_;
+    custom_attributes_ = other.custom_attributes_;
     otel_stage_.reset();
+    otel_child_spans_.clear();
 }
 
 Measurement &Measurement::operator=(const Measurement &other) {
@@ -92,7 +94,9 @@ Measurement &Measurement::operator=(const Measurement &other) {
     out_channel_ = other.out_channel_;
     error_type_ = other.error_type_;
     error_message_ = other.error_message_;
+    custom_attributes_ = other.custom_attributes_;
     otel_stage_.reset();
+    otel_child_spans_.clear();
     return *this;
 }
 
@@ -106,87 +110,70 @@ std::shared_ptr<Measurement> Measurement::clone() const {
     clone->error_type_.reset();
     clone->error_message_.reset();
     clone->otel_stage_.reset();
+    clone->otel_child_spans_.clear();
     return std::shared_ptr(std::move(clone));
 }
 
 Measurement & Measurement::set_trace_root_tx_hash(const td::Bits256 &trace_root_tx_hash) {
     std::lock_guard<std::mutex> lock(mutex_);
     trace_root_tx_hash_ = trace_root_tx_hash;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace.root_tx_hash", td::base64_encode(trace_root_tx_hash.as_slice()));
-    }
+    set_attribute_locked("ton.trace.root_tx_hash", td::base64_encode(trace_root_tx_hash.as_slice()));
     return *this;
 }
 
 Measurement & Measurement::set_ext_msg_hash(const td::Bits256 &ext_msg_hash) {
     std::lock_guard<std::mutex> lock(mutex_);
     ext_msg_hash_ = ext_msg_hash;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace.external_message_hash", td::base64_encode(ext_msg_hash.as_slice()));
-    }
+    set_attribute_locked("ton.trace.external_message_hash", td::base64_encode(ext_msg_hash.as_slice()));
     return *this;
 }
 
 Measurement &Measurement::set_ext_msg_hash_norm(const td::Bits256 &ext_msg_hash_norm) {
     std::lock_guard<std::mutex> lock(mutex_);
     ext_msg_hash_norm_ = ext_msg_hash_norm;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace.external_message_hash_norm", td::base64_encode(ext_msg_hash_norm.as_slice()));
-    }
+    set_attribute_locked("ton.trace.external_message_hash_norm", td::base64_encode(ext_msg_hash_norm.as_slice()));
     return *this;
 }
 
 Measurement &Measurement::set_finality(const std::string& finality) {
     std::lock_guard<std::mutex> lock(mutex_);
     finality_ = finality;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace.finality", finality);
-    }
+    set_attribute_locked("ton.trace.finality", finality);
     return *this;
 }
 
 Measurement &Measurement::set_operation(const std::string& operation) {
     std::lock_guard<std::mutex> lock(mutex_);
     operation_ = operation;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace_emulator.operation", operation);
-    }
+    set_attribute_locked("ton.trace_emulator.operation", operation);
     return *this;
 }
 
 Measurement &Measurement::set_source(const std::string& source) {
     std::lock_guard<std::mutex> lock(mutex_);
     source_ = source;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace_emulator.source", source);
-    }
+    set_attribute_locked("ton.trace_emulator.source", source);
     return *this;
 }
 
 Measurement &Measurement::set_transactions_count(std::int64_t transactions_count) {
     std::lock_guard<std::mutex> lock(mutex_);
     transactions_count_ = transactions_count;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace.transactions_count", transactions_count);
-    }
+    set_attribute_locked("ton.trace.transactions_count", transactions_count);
     return *this;
 }
 
 Measurement &Measurement::set_emulated_transactions_count(std::int64_t emulated_transactions_count) {
     std::lock_guard<std::mutex> lock(mutex_);
     emulated_transactions_count_ = emulated_transactions_count;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.trace.emulated_transactions_count", emulated_transactions_count);
-    }
+    set_attribute_locked("ton.trace.emulated_transactions_count", emulated_transactions_count);
     return *this;
 }
 
 Measurement &Measurement::set_out_channel(const std::string& out_channel) {
     std::lock_guard<std::mutex> lock(mutex_);
     out_channel_ = out_channel;
-    if (otel_stage_) {
-        otel_stage_->set_attribute("ton.redis.out.channel", out_channel);
-    }
+    set_attribute_locked("ton.redis.out.channel", out_channel);
     return *this;
 }
 
@@ -197,6 +184,84 @@ Measurement &Measurement::mark_otel_error(const std::string& error_type, const s
     if (otel_stage_) {
         otel_stage_->mark_error(error_type, error_message);
     }
+    for (auto& [_, child_span] : otel_child_spans_) {
+        child_span->mark_error(error_type, error_message);
+    }
+    return *this;
+}
+
+Measurement &Measurement::set_otel_attribute(const std::string& key, const std::string& value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    custom_attributes_[key] = value;
+    set_attribute_locked(key, value);
+    return *this;
+}
+
+Measurement &Measurement::set_otel_attribute(const std::string& key, const char* value) {
+    if (!value || value[0] == '\0') {
+        return *this;
+    }
+    return set_otel_attribute(key, std::string(value));
+}
+
+Measurement &Measurement::set_otel_attribute(const std::string& key, bool value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    custom_attributes_[key] = value;
+    set_attribute_locked(key, value);
+    return *this;
+}
+
+Measurement &Measurement::set_otel_attribute(const std::string& key, std::int64_t value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    custom_attributes_[key] = value;
+    set_attribute_locked(key, value);
+    return *this;
+}
+
+Measurement &Measurement::start_otel_child_span(const std::string& service_stage) {
+    if (!OtelStageSpan::tracing_enabled() || service_stage.empty()) {
+        return *this;
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    ensure_trace_emulator_stage_locked();
+
+    auto existing = otel_child_spans_.find(service_stage);
+    if (existing != otel_child_spans_.end()) {
+        existing->second->end();
+        otel_child_spans_.erase(existing);
+    }
+
+    OtelStageSpan::Options options;
+    options.service_name = "ton-trace-emulator";
+    options.span_name = std::string("ton.trace_emulator.") + service_stage;
+    options.pipeline = "trace_to_actions_to_stream";
+    options.service_stage = service_stage;
+    options.kind = opentelemetry::trace::SpanKind::kInternal;
+    options.parent = otel_stage_
+        ? std::optional<opentelemetry::trace::SpanContext>(otel_stage_->context())
+        : std::nullopt;
+    options.start_system_time_ns = OtelStageSpan::system_now_ns();
+    options.start_steady_time_ns = OtelStageSpan::steady_now_ns();
+
+    auto child_span = std::make_unique<OtelStageSpan>(std::move(options));
+    apply_common_attributes_locked(*child_span);
+    if (error_type_) {
+        child_span->mark_error(*error_type_, error_message_.value_or(*error_type_));
+    }
+    otel_child_spans_[service_stage] = std::move(child_span);
+    return *this;
+}
+
+Measurement &Measurement::end_otel_child_span(const std::string& service_stage) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = otel_child_spans_.find(service_stage);
+    if (it == otel_child_spans_.end()) {
+        return *this;
+    }
+    apply_common_attributes_locked(*it->second);
+    it->second->end();
+    otel_child_spans_.erase(it);
     return *this;
 }
 
@@ -210,36 +275,58 @@ void Measurement::ensure_trace_emulator_stage_locked() {
             start_steady_time_ns_
         );
     }
-    otel_stage_->set_attribute("ton.processing.pass_id", pass_id_);
-    if (!b64_hash_or_empty(ext_msg_hash_).empty()) {
-        otel_stage_->set_attribute("ton.trace.external_message_hash", b64_hash_or_empty(ext_msg_hash_));
-    }
-    if (!b64_hash_or_empty(ext_msg_hash_norm_).empty()) {
-        otel_stage_->set_attribute("ton.trace.external_message_hash_norm", b64_hash_or_empty(ext_msg_hash_norm_));
-    }
-    if (!b64_hash_or_empty(trace_root_tx_hash_).empty()) {
-        otel_stage_->set_attribute("ton.trace.root_tx_hash", b64_hash_or_empty(trace_root_tx_hash_));
-    }
-    if (finality_) {
-        otel_stage_->set_attribute("ton.trace.finality", *finality_);
-    }
-    if (operation_) {
-        otel_stage_->set_attribute("ton.trace_emulator.operation", *operation_);
-    }
-    if (source_) {
-        otel_stage_->set_attribute("ton.trace_emulator.source", *source_);
-    }
-    if (transactions_count_) {
-        otel_stage_->set_attribute("ton.trace.transactions_count", *transactions_count_);
-    }
-    if (emulated_transactions_count_) {
-        otel_stage_->set_attribute("ton.trace.emulated_transactions_count", *emulated_transactions_count_);
-    }
-    if (out_channel_) {
-        otel_stage_->set_attribute("ton.redis.out.channel", *out_channel_);
-    }
+    apply_common_attributes_locked(*otel_stage_);
     if (error_type_) {
         otel_stage_->mark_error(*error_type_, error_message_.value_or(*error_type_));
+    }
+}
+
+void Measurement::apply_common_attributes_locked(OtelStageSpan& span) {
+    span.set_attribute("ton.processing.pass_id", pass_id_);
+    if (!b64_hash_or_empty(ext_msg_hash_).empty()) {
+        span.set_attribute("ton.trace.external_message_hash", b64_hash_or_empty(ext_msg_hash_));
+    }
+    if (!b64_hash_or_empty(ext_msg_hash_norm_).empty()) {
+        span.set_attribute("ton.trace.external_message_hash_norm", b64_hash_or_empty(ext_msg_hash_norm_));
+    }
+    if (!b64_hash_or_empty(trace_root_tx_hash_).empty()) {
+        span.set_attribute("ton.trace.root_tx_hash", b64_hash_or_empty(trace_root_tx_hash_));
+    }
+    if (finality_) {
+        span.set_attribute("ton.trace.finality", *finality_);
+    }
+    if (operation_) {
+        span.set_attribute("ton.trace_emulator.operation", *operation_);
+    }
+    if (source_) {
+        span.set_attribute("ton.trace_emulator.source", *source_);
+    }
+    if (transactions_count_) {
+        span.set_attribute("ton.trace.transactions_count", *transactions_count_);
+    }
+    if (emulated_transactions_count_) {
+        span.set_attribute("ton.trace.emulated_transactions_count", *emulated_transactions_count_);
+    }
+    if (out_channel_) {
+        span.set_attribute("ton.redis.out.channel", *out_channel_);
+    }
+    for (const auto& [key, value] : custom_attributes_) {
+        std::visit([&](const auto& typed_value) {
+            span.set_attribute(key, typed_value);
+        }, value);
+    }
+}
+
+void Measurement::set_attribute_locked(const std::string& key, const OtelStageSpan::AttributeValue& value) {
+    if (otel_stage_) {
+        std::visit([&](const auto& typed_value) {
+            otel_stage_->set_attribute(key, typed_value);
+        }, value);
+    }
+    for (auto& [_, child_span] : otel_child_spans_) {
+        std::visit([&](const auto& typed_value) {
+            child_span->set_attribute(key, typed_value);
+        }, value);
     }
 }
 
@@ -253,6 +340,10 @@ Measurement &Measurement::emit_otel_span() {
     std::lock_guard<std::mutex> lock(mutex_);
     ensure_trace_emulator_stage_locked();
     if (otel_stage_) {
+        for (auto& [_, child_span] : otel_child_spans_) {
+            child_span->end();
+        }
+        otel_child_spans_.clear();
         otel_stage_->emit();
     }
     return *this;

--- a/ton-index-worker/ton-trace-emulator/src/Measurement.h
+++ b/ton-index-worker/ton-trace-emulator/src/Measurement.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -27,9 +28,13 @@ class Measurement {
     std::optional<std::string> out_channel_{std::nullopt};
     std::optional<std::string> error_type_{std::nullopt};
     std::optional<std::string> error_message_{std::nullopt};
+    std::map<std::string, OtelStageSpan::AttributeValue> custom_attributes_;
     std::unique_ptr<OtelStageSpan> otel_stage_;
+    std::map<std::string, std::unique_ptr<OtelStageSpan>> otel_child_spans_;
 
     void ensure_trace_emulator_stage_locked();
+    void apply_common_attributes_locked(OtelStageSpan& span);
+    void set_attribute_locked(const std::string& key, const OtelStageSpan::AttributeValue& value);
 public:
     Measurement();
 
@@ -59,6 +64,14 @@ public:
     Measurement &set_out_channel(const std::string& out_channel);
 
     Measurement &mark_otel_error(const std::string& error_type, const std::string& error_message);
+
+    Measurement &set_otel_attribute(const std::string& key, const std::string& value);
+    Measurement &set_otel_attribute(const std::string& key, const char* value);
+    Measurement &set_otel_attribute(const std::string& key, bool value);
+    Measurement &set_otel_attribute(const std::string& key, std::int64_t value);
+
+    Measurement &start_otel_child_span(const std::string& service_stage);
+    Measurement &end_otel_child_span(const std::string& service_stage);
 
     std::map<std::string, std::string> otel_propagation_fields();
 

--- a/ton-index-worker/ton-trace-emulator/src/OverlayListener.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/OverlayListener.cpp
@@ -1,5 +1,6 @@
 
 #include "OverlayListener.h"
+#include <cstdint>
 #include <tdutils/td/utils/filesystem.h>
 #include "TraceInterfaceDetector.h"
 
@@ -129,6 +130,8 @@ void OverlayListener::process_external_message(td::Ref<ton::validator::ExtMessag
     measurement->set_source("overlay");
     measurement->set_ext_msg_hash_norm(msg_hash_norm);
     measurement->set_ext_msg_hash(message->root_cell()->get_hash().bits());
+    measurement->start_otel_child_span("prepare_input");
+    measurement->end_otel_child_span("prepare_input");
 
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), msg_hash_norm, measurement](td::Result<Trace> R) mutable {
         if (R.is_error()) {
@@ -137,6 +140,7 @@ void OverlayListener::process_external_message(td::Ref<ton::validator::ExtMessag
             td::actor::send_closure(SelfId, &OverlayListener::trace_received, R.move_as_ok(), measurement);
         }
     });
+    measurement->start_otel_child_span("emulate_tail");
     td::actor::create_actor<TraceEmulator>("TraceEmu", mc_data_state_, message->root_cell(), false, std::move(P), measurement).release();
 
     g_statistics.record_count(EMULATE_SRC_OVERLAY);
@@ -145,15 +149,18 @@ void OverlayListener::process_external_message(td::Ref<ton::validator::ExtMessag
 void OverlayListener::trace_error(td::Bits256 ext_in_msg_hash_norm, td::Status error, MeasurementPtr measurement) {
     LOG(ERROR) << "Failed to emulate trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice()) << ": " << error;
     measurement->mark_otel_error("trace_emulator.emulation_error", error.to_string());
+    measurement->end_otel_child_span("emulate_tail");
     measurement->emit_otel_span();
 }
 
 void OverlayListener::trace_received(Trace trace, MeasurementPtr measurement) {
-    LOG(INFO) << "Emulated trace from msg " << td::base64_encode(trace.ext_in_msg_hash_norm.as_slice()) << ": " 
+    measurement->end_otel_child_span("emulate_tail");
+    LOG(INFO) << "Emulated trace from msg " << td::base64_encode(trace.ext_in_msg_hash_norm.as_slice()) << ": "
         << trace.transactions_count() << " transactions, " << trace.depth() << " depth";
     measurement->set_transactions_count(trace.transactions_count());
     measurement->set_emulated_transactions_count(trace.root ? trace.root->emulated_transactions_count() : 0);
     measurement->set_trace_root_tx_hash(trace.root_tx_hash);
+    measurement->set_otel_attribute("ton.trace.depth", static_cast<std::int64_t>(trace.depth()));
     if constexpr (std::variant_size_v<Trace::Detector::DetectedInterface> > 0) {
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), ext_in_msg_hash_norm = trace.ext_in_msg_hash_norm, measurement](td::Result<Trace> R) {
             if (R.is_error()) {
@@ -168,6 +175,7 @@ void OverlayListener::trace_received(Trace trace, MeasurementPtr measurement) {
             shard_states.push_back(shard_state.block_state);
         }
 
+        measurement->start_otel_child_span("detect_interfaces");
         td::actor::create_actor<TraceInterfaceDetector>("TraceInterfaceDetector", std::move(shard_states), mc_data_state_.config_, std::move(trace), std::move(P), measurement).release();
     } else {
         finish_processing(std::move(trace), measurement);
@@ -177,19 +185,24 @@ void OverlayListener::trace_received(Trace trace, MeasurementPtr measurement) {
 void OverlayListener::trace_interfaces_error(td::Bits256 ext_in_msg_hash_norm, td::Status error, MeasurementPtr measurement) {
     LOG(ERROR) << "Failed to detect interfaces on trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice()) << ": " << error;
     measurement->mark_otel_error("trace_emulator.interface_error", error.to_string());
+    measurement->end_otel_child_span("detect_interfaces");
     measurement->emit_otel_span();
 }
 
 void OverlayListener::finish_processing(Trace trace, MeasurementPtr measurement) {
+    measurement->end_otel_child_span("detect_interfaces");
+    measurement->start_otel_child_span("insert_trace");
     auto P = td::PromiseCreator::lambda([ext_in_msg_hash_norm = trace.ext_in_msg_hash_norm, measurement](td::Result<td::Unit> R) {
         if (R.is_error()) {
             auto error = R.move_as_error();
             LOG(ERROR) << "Failed to insert trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice()) << ": " << error;
             measurement->mark_otel_error("trace_emulator.insert_error", error.to_string());
+            measurement->end_otel_child_span("insert_trace");
             measurement->emit_otel_span();
             return;
         }
         LOG(DEBUG) << "Successfully inserted trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice());
+        measurement->end_otel_child_span("insert_trace");
         measurement->emit_otel_span();
     });
     trace_processor_(std::move(trace), std::move(P), measurement);

--- a/ton-index-worker/ton-trace-emulator/src/OverlayListener.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/OverlayListener.cpp
@@ -118,7 +118,19 @@ void OverlayListener::process_external_message(td::Ref<ton::validator::ExtMessag
         return;
     }
     auto msg_hash_norm = msg_hash_norm_r.move_as_ok();
-    if (!known_ext_msgs_.insert(msg_hash_norm).second) {
+
+    auto destination = block::StdAddress(message->wc(), message->addr());
+    auto admission = external_message_admission_->try_acquire(msg_hash_norm, destination);
+    if (!admission.accepted) {
+        if (admission.reject_reason == ExternalMessageAdmission::RejectReason::Duplicate) {
+            LOG(DEBUG) << "Skipping duplicate overlay external message " << td::base64_encode(msg_hash_norm.as_slice());
+        } else {
+            LOG(DEBUG) << "Rate-limited overlay external message " << td::base64_encode(msg_hash_norm.as_slice())
+                << " for destination " << destination.workchain << ":" << destination.addr.to_hex()
+                << " (" << admission.accepted_for_destination << "/"
+                << ExternalMessageAdmission::kDefaultMaxEmulationsPerDestination << " in "
+                << ExternalMessageAdmission::kDefaultWindowSeconds << "s)";
+        }
         return;
     }
 
@@ -151,10 +163,12 @@ void OverlayListener::trace_error(td::Bits256 ext_in_msg_hash_norm, td::Status e
     measurement->mark_otel_error("trace_emulator.emulation_error", error.to_string());
     measurement->end_otel_child_span("emulate_tail");
     measurement->emit_otel_span();
+    external_message_admission_->release_message(ext_in_msg_hash_norm);
 }
 
 void OverlayListener::trace_received(Trace trace, MeasurementPtr measurement) {
     measurement->end_otel_child_span("emulate_tail");
+    external_message_admission_->mark_emulated(trace.ext_in_msg_hash_norm);
     LOG(INFO) << "Emulated trace from msg " << td::base64_encode(trace.ext_in_msg_hash_norm.as_slice()) << ": "
         << trace.transactions_count() << " transactions, " << trace.depth() << " depth";
     measurement->set_transactions_count(trace.transactions_count());

--- a/ton-index-worker/ton-trace-emulator/src/OverlayListener.h
+++ b/ton-index-worker/ton-trace-emulator/src/OverlayListener.h
@@ -6,6 +6,8 @@
 #include <overlay/overlays.h>
 #include <validator/impl/external-message.hpp>
 #include <emulator/transaction-emulator.h>
+#include <memory>
+#include "ExternalMessageAdmission.h"
 #include "IndexData.h"
 #include "Measurement.h"
 #include "TraceEmulator.h"
@@ -17,6 +19,7 @@ private:
     std::string global_config_path_;
     std::string inet_addr_;
     TraceProcessorFn trace_processor_;
+    std::shared_ptr<ExternalMessageAdmission> external_message_admission_;
 
     td::actor::ActorOwn<ton::overlay::Overlays> overlays_;
     td::actor::ActorOwn<ton::adnl::Adnl> adnl_;
@@ -25,7 +28,6 @@ private:
     td::actor::ActorOwn<ton::adnl::AdnlNetworkManager> adnl_network_manager_;
 
     schema::MasterchainBlockDataState mc_data_state_;
-    std::unordered_set<td::Bits256> known_ext_msgs_;
     
     int traces_cnt_{0};
 
@@ -36,13 +38,18 @@ private:
     void finish_processing(Trace trace, MeasurementPtr measurement);
 
 public:
-    OverlayListener(std::string global_config_path, std::string inet_addr, TraceProcessorFn trace_processor)
-        : global_config_path_(std::move(global_config_path)), inet_addr_(std::move(inet_addr)), trace_processor_(std::move(trace_processor)) {};
+    OverlayListener(std::string global_config_path, std::string inet_addr, TraceProcessorFn trace_processor,
+                    std::shared_ptr<ExternalMessageAdmission> external_message_admission = nullptr)
+        : global_config_path_(std::move(global_config_path)), inet_addr_(std::move(inet_addr)),
+          trace_processor_(std::move(trace_processor)), external_message_admission_(std::move(external_message_admission)) {
+        if (!external_message_admission_) {
+            external_message_admission_ = std::make_shared<ExternalMessageAdmission>();
+        }
+    };
 
     virtual void start_up() override;
 
     void set_mc_data_state(schema::MasterchainBlockDataState mc_data_state) {
         mc_data_state_ = std::move(mc_data_state);
-        known_ext_msgs_.clear();
     }
 };

--- a/ton-index-worker/ton-trace-emulator/src/RedisListener.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/RedisListener.cpp
@@ -3,6 +3,8 @@
 #include "Measurement.h"
 #include "Statistics.h"
 
+#include <cstdint>
+
 void ChannelListener::setup_subscriber() {
   sw::redis::ConnectionOptions connection_options = sw::redis::Uri(redis_dsn_).connection_options();
   connection_options.socket_timeout = std::chrono::milliseconds(100);
@@ -83,6 +85,8 @@ void RedisListener::on_new_message(td::Ref<vm::Cell> msg_cell) {
   measurement->set_source("redis");
   measurement->set_ext_msg_hash_norm(msg_hash_norm);
   measurement->set_ext_msg_hash(msg_cell->get_hash().bits());
+  measurement->start_otel_child_span("prepare_input");
+  measurement->end_otel_child_span("prepare_input");
   auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), measurement, msg_hash_norm](td::Result<Trace> R) mutable {
     if (R.is_error()) {
       td::actor::send_closure(SelfId, &RedisListener::trace_error, msg_hash_norm, R.move_as_error(), measurement);
@@ -91,6 +95,7 @@ void RedisListener::on_new_message(td::Ref<vm::Cell> msg_cell) {
     }
   });
 
+  measurement->start_otel_child_span("emulate_tail");
   td::actor::create_actor<TraceEmulator>("TraceEmu", mc_data_state_, msg_cell, false, std::move(P), measurement).release();
 
   g_statistics.record_count(EMULATE_SRC_REDIS);
@@ -109,16 +114,19 @@ void RedisListener::set_mc_data_state(schema::MasterchainBlockDataState mc_data_
 void RedisListener::trace_error(td::Bits256 ext_in_msg_hash_norm, td::Status error, MeasurementPtr measurement) {
   LOG(ERROR) << "Failed to emulate trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice()) << ": " << error;
   measurement->mark_otel_error("trace_emulator.emulation_error", error.to_string());
+  measurement->end_otel_child_span("emulate_tail");
   measurement->emit_otel_span();
   known_ext_msgs_.erase(ext_in_msg_hash_norm);
 }
 
 void RedisListener::trace_received(Trace trace, MeasurementPtr measurement) {
+  measurement->end_otel_child_span("emulate_tail");
   LOG(INFO) << "Emulated trace from msg " << td::base64_encode(trace.ext_in_msg_hash_norm.as_slice()) << ": "
         << trace.transactions_count() << " transactions, " << trace.depth() << " depth";
   measurement->set_transactions_count(trace.transactions_count());
   measurement->set_emulated_transactions_count(trace.root ? trace.root->emulated_transactions_count() : 0);
   measurement->set_trace_root_tx_hash(trace.root_tx_hash);
+  measurement->set_otel_attribute("ton.trace.depth", static_cast<std::int64_t>(trace.depth()));
   if constexpr (std::variant_size_v<Trace::Detector::DetectedInterface> > 0) {
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), measurement, ext_in_msg_hash_norm = trace.ext_in_msg_hash_norm](td::Result<Trace> R) {
       if (R.is_error()) {
@@ -128,6 +136,7 @@ void RedisListener::trace_received(Trace trace, MeasurementPtr measurement) {
       td::actor::send_closure(SelfId, &RedisListener::finish_processing, R.move_as_ok(), measurement);
     });
 
+    measurement->start_otel_child_span("detect_interfaces");
     td::actor::create_actor<TraceInterfaceDetector>("TraceInterfaceDetector", shard_states_, mc_data_state_.config_, std::move(trace), std::move(P), measurement).release();
   } else {
     finish_processing(std::move(trace), measurement);
@@ -137,19 +146,24 @@ void RedisListener::trace_received(Trace trace, MeasurementPtr measurement) {
 void RedisListener::trace_interfaces_error(td::Bits256 ext_in_msg_hash_norm, td::Status error, MeasurementPtr measurement) {
   LOG(ERROR) << "Failed to detect interfaces on trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice()) << ": " << error;
   measurement->mark_otel_error("trace_emulator.interface_error", error.to_string());
+  measurement->end_otel_child_span("detect_interfaces");
   measurement->emit_otel_span();
 }
 
 void RedisListener::finish_processing(Trace trace, MeasurementPtr measurement) {
+  measurement->end_otel_child_span("detect_interfaces");
+  measurement->start_otel_child_span("insert_trace");
   auto P = td::PromiseCreator::lambda([ext_in_msg_hash_norm = trace.ext_in_msg_hash_norm, measurement](td::Result<td::Unit> R) {
     if (R.is_error()) {
       auto error = R.move_as_error();
       LOG(ERROR) << "Failed to insert trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice()) << ": " << error;
       measurement->mark_otel_error("trace_emulator.insert_error", error.to_string());
+      measurement->end_otel_child_span("insert_trace");
       measurement->emit_otel_span();
       return;
     }
     LOG(DEBUG) << "Successfully inserted trace from msg " << td::base64_encode(ext_in_msg_hash_norm.as_slice());
+    measurement->end_otel_child_span("insert_trace");
     measurement->emit_otel_span();
   });
   trace_processor_(std::move(trace), std::move(P), measurement);

--- a/ton-index-worker/ton-trace-emulator/src/RedisListener.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/RedisListener.cpp
@@ -52,8 +52,14 @@ void ChannelListener::alarm() {
   alarm_timestamp() = td::Timestamp::now();
 }
 
-RedisListener::RedisListener(std::string redis_dsn, std::string channel_name, std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor)
-        : redis_dsn_(redis_dsn), channel_name_(channel_name), trace_processor_(std::move(trace_processor)) {
+RedisListener::RedisListener(std::string redis_dsn, std::string channel_name,
+                             std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> trace_processor,
+                             std::shared_ptr<ExternalMessageAdmission> external_message_admission)
+        : redis_dsn_(redis_dsn), channel_name_(channel_name), trace_processor_(std::move(trace_processor)),
+          external_message_admission_(std::move(external_message_admission)) {
+  if (!external_message_admission_) {
+    external_message_admission_ = std::make_shared<ExternalMessageAdmission>();
+  }
 }
 
 void RedisListener::start_up() {
@@ -75,10 +81,30 @@ void RedisListener::on_new_message(td::Ref<vm::Cell> msg_cell) {
     return;
   }
   auto msg_hash_norm = msg_hash_norm_r.move_as_ok();
-  auto [x, inserted] = known_ext_msgs_.insert(msg_hash_norm);
-  if (!inserted) {
+
+  int msg_type = -1;
+  auto destination_r = fetch_msg_dest_address(msg_cell, msg_type);
+  if (destination_r.is_error() || msg_type != block::gen::CommonMsgInfo::ext_in_msg_info) {
+    LOG(ERROR) << "Failed to get destination for external message: " << td::base64_encode(msg_hash_norm.as_slice())
+               << ": " << (destination_r.is_error() ? destination_r.move_as_error().to_string() : "unexpected message type");
     return;
   }
+  auto destination = destination_r.move_as_ok();
+
+  auto admission = external_message_admission_->try_acquire(msg_hash_norm, destination);
+  if (!admission.accepted) {
+    if (admission.reject_reason == ExternalMessageAdmission::RejectReason::Duplicate) {
+      LOG(DEBUG) << "Skipping duplicate redis external message " << td::base64_encode(msg_hash_norm.as_slice());
+    } else {
+      LOG(DEBUG) << "Rate-limited redis external message " << td::base64_encode(msg_hash_norm.as_slice())
+                 << " for destination " << destination.workchain << ":" << destination.addr.to_hex()
+                 << " (" << admission.accepted_for_destination << "/"
+                 << ExternalMessageAdmission::kDefaultMaxEmulationsPerDestination << " in "
+                 << ExternalMessageAdmission::kDefaultWindowSeconds << "s)";
+    }
+    return;
+  }
+
   auto measurement = std::make_shared<Measurement>();
   measurement->set_finality("pending");
   measurement->set_operation("emulate");
@@ -108,7 +134,6 @@ void RedisListener::set_mc_data_state(schema::MasterchainBlockDataState mc_data_
   }
 
   mc_data_state_ = std::move(mc_data_state);
-  known_ext_msgs_.clear();
 }
 
 void RedisListener::trace_error(td::Bits256 ext_in_msg_hash_norm, td::Status error, MeasurementPtr measurement) {
@@ -116,11 +141,12 @@ void RedisListener::trace_error(td::Bits256 ext_in_msg_hash_norm, td::Status err
   measurement->mark_otel_error("trace_emulator.emulation_error", error.to_string());
   measurement->end_otel_child_span("emulate_tail");
   measurement->emit_otel_span();
-  known_ext_msgs_.erase(ext_in_msg_hash_norm);
+  external_message_admission_->release_message(ext_in_msg_hash_norm);
 }
 
 void RedisListener::trace_received(Trace trace, MeasurementPtr measurement) {
   measurement->end_otel_child_span("emulate_tail");
+  external_message_admission_->mark_emulated(trace.ext_in_msg_hash_norm);
   LOG(INFO) << "Emulated trace from msg " << td::base64_encode(trace.ext_in_msg_hash_norm.as_slice()) << ": "
         << trace.transactions_count() << " transactions, " << trace.depth() << " depth";
   measurement->set_transactions_count(trace.transactions_count());

--- a/ton-index-worker/ton-trace-emulator/src/RedisListener.h
+++ b/ton-index-worker/ton-trace-emulator/src/RedisListener.h
@@ -3,7 +3,9 @@
 #include <validator/impl/external-message.hpp>
 #include <emulator/transaction-emulator.h>
 #include <sw/redis++/redis++.h>
+#include <memory>
 #include "IndexData.h"
+#include "ExternalMessageAdmission.h"
 #include "TraceEmulator.h"
 #include "TraceInterfaceDetector.h"
 #include "Measurement.h"
@@ -31,16 +33,16 @@ private:
   std::string redis_dsn_;
   std::string channel_name_;
   TraceProcessorFn trace_processor_;
+  std::shared_ptr<ExternalMessageAdmission> external_message_admission_;
 
   schema::MasterchainBlockDataState mc_data_state_;
   std::vector<td::Ref<vm::Cell>> shard_states_;
 
-  std::unordered_set<td::Bits256> known_ext_msgs_;
-
   td::actor::ActorOwn<ChannelListener> channel_listener_;
 
 public:
-  RedisListener(std::string redis_dsn, std::string channel_name, TraceProcessorFn trace_processor);
+  RedisListener(std::string redis_dsn, std::string channel_name, TraceProcessorFn trace_processor,
+                std::shared_ptr<ExternalMessageAdmission> external_message_admission = nullptr);
   void start_up() override;
   void set_mc_data_state(schema::MasterchainBlockDataState mc_data_state);
 private:

--- a/ton-index-worker/ton-trace-emulator/src/TraceEmulator.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceEmulator.cpp
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <emulator/transaction-emulator.h>
@@ -269,6 +270,10 @@ void MasterchainBlockEmulator::start_up() {
             return;
         }
     }
+    if (measurement_) {
+        measurement_->set_otel_attribute("ton.emulator.input_messages_count", static_cast<std::int64_t>(in_msgs_.size()));
+        measurement_->set_otel_attribute("ton.emulator.shards_count", static_cast<std::int64_t>(buckets.size()));
+    }
 
     td::MultiPromise mp;
     auto ig = mp.init_guard();
@@ -378,6 +383,9 @@ void MasterchainBlockEmulator::all_shards_emulated() {
     }
 
     if (context_.is_limit_exceeded()) {
+        if (measurement_) {
+            measurement_->set_otel_attribute("ton.trace.tx_limit_exceeded", true);
+        }
         promise_.set_result(std::move(result_));
         stop();
         return;
@@ -397,6 +405,9 @@ void MasterchainBlockEmulator::all_shards_emulated() {
         promise_.set_result(std::move(result_));
         stop();
         return;
+    }
+    if (measurement_) {
+        measurement_->set_otel_attribute("ton.emulator.next_messages_count", static_cast<std::int64_t>(to_emulate_in_next_mc_block.size()));
     }
 
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<std::vector<std::unique_ptr<TraceNode>>> R) {
@@ -509,6 +520,9 @@ void TraceEmulator::finish(td::Result<std::vector<std::unique_ptr<TraceNode>>> r
         return;
     }
 
+    if (measurement_) {
+        measurement_->start_otel_child_span("build_trace_tree");
+    }
     Trace result;
     auto ext_in_msg_hash_norm = ext_in_msg_get_normalized_hash(in_msg_);
     if (ext_in_msg_hash_norm.is_ok()) {
@@ -521,6 +535,9 @@ void TraceEmulator::finish(td::Result<std::vector<std::unique_ptr<TraceNode>>> r
     result.rand_seed = context_->get_rand_seed();
     result.emulated_accounts = context_->release_account_states();
     result.tx_limit_exceeded = context_->is_limit_exceeded();
+    if (measurement_) {
+        measurement_->end_otel_child_span("build_trace_tree");
+    }
     promise_.set_result(std::move(result));
     g_statistics.record_time(EMULATE_TRACE, timer_.elapsed() * 1e3);
     stop();

--- a/ton-index-worker/ton-trace-emulator/src/TraceInserter.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceInserter.cpp
@@ -1,6 +1,7 @@
 #include "TraceInserter.h"
 #include "Serializer.hpp"
 #include "Statistics.h"
+#include <cstdint>
 #include <optional>
 #include <queue>
 
@@ -48,6 +49,7 @@ public:
 
             trace_key_ = td::base64_encode(trace_.ext_in_msg_hash_norm.as_slice());
             auto existing_fields_count = transaction_.redis().hlen(trace_key_);
+            measurement_->set_otel_attribute("ton.redis.existing_fields_count", static_cast<std::int64_t>(existing_fields_count));
             if (existing_fields_count > static_cast<long long>(kMaxExistingTraceFields)) {
                 LOG(WARNING) << "Skipping trace insert for " << trace_key_
                              << ": existing trace hash is too large (" << existing_fields_count << " fields)";
@@ -98,10 +100,13 @@ public:
             }
 
             if (flattened_trace.empty()) {
+                measurement_->set_otel_attribute("ton.redis.flattened_nodes_count", static_cast<std::int64_t>(0));
                 promise_.set_value(td::Unit());
                 stop();
                 return;
             }
+            measurement_->set_otel_attribute("ton.redis.flattened_nodes_count", static_cast<std::int64_t>(flattened_trace.size()));
+            measurement_->set_otel_attribute("ton.redis.deleted_nodes_count", static_cast<std::int64_t>(tx_keys_to_delete.size()));
 
             // delete previously emulated trace
             if (tx_keys_to_delete.size() > 0) {

--- a/ton-index-worker/ton-trace-emulator/src/TraceInterfaceDetector.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceInterfaceDetector.cpp
@@ -2,6 +2,8 @@
 #include "smc-interfaces/InterfacesDetector.h"
 #include "smc-interfaces/FetchAccountFromShard.h"
 
+#include <cstdint>
+
 void TraceInterfaceDetector::start_up() {
     td::MultiPromise mp;
     auto ig = mp.init_guard();
@@ -12,6 +14,8 @@ void TraceInterfaceDetector::start_up() {
 
     // Detect interfaces for final state of each emulated account
     std::unordered_set<block::StdAddress> processed_addresses;
+    std::int64_t emulated_detector_tasks = 0;
+    std::int64_t committed_detector_tasks = 0;
     for (auto it = trace_.emulated_accounts.rbegin(); it != trace_.emulated_accounts.rend(); it++) {
         const auto& [address, account] = *it;
         if (processed_addresses.count(address)) {
@@ -20,16 +24,17 @@ void TraceInterfaceDetector::start_up() {
         processed_addresses.insert(address);
         trace_.interfaces[address] = {};
         td::actor::create_actor<Trace::Detector>
-            ("InterfacesDetector", address, account.code, account.data, shard_states_, config_, 
+            ("InterfacesDetector", address, account.code, account.data, shard_states_, config_,
             td::PromiseCreator::lambda([SelfId = actor_id(this), address, promise = ig.get_promise()](std::vector<typename Trace::Detector::DetectedInterface> interfaces) mutable {
                 td::actor::send_closure(SelfId, &TraceInterfaceDetector::got_interfaces, address, std::move(interfaces), false, std::move(promise));
-        })).release();
+            })).release();
+        emulated_detector_tasks++;
     }
 
     // For committed accounts fetch block::Account and detect interfaces
     for (const auto& address : trace_.get_addresses(true)) {
         std::optional<block::Account> account_state;
-        
+
         for (const auto& shard_state : shard_states_) {
             block::gen::ShardStateUnsplit::Record sstate;
             if (!tlb::unpack_cell(shard_state, sstate)) {
@@ -71,12 +76,18 @@ void TraceInterfaceDetector::start_up() {
             td::actor::create_actor<Trace::Detector>("InterfacesDetector", address, account_state->code, account_state->data, shard_states_, config_,
                 td::PromiseCreator::lambda([SelfId = actor_id(this), address, promise = ig.get_promise()](std::vector<typename Trace::Detector::DetectedInterface> interfaces) mutable {
                     td::actor::send_closure(SelfId, &TraceInterfaceDetector::got_interfaces, address, std::move(interfaces), true, std::move(promise));
-            })).release();
+                })).release();
         } else {
             // Account is not active, skip interface detection
             LOG(DEBUG) << "Account " << std::to_string(address.workchain) << ":" << address.addr.to_hex() << " is not active, skipping interface detection";
             got_interfaces(address, {}, true, ig.get_promise());
         }
+        committed_detector_tasks++;
+    }
+    if (measurement_) {
+        measurement_->set_otel_attribute("ton.interfaces.emulated_accounts_count", emulated_detector_tasks);
+        measurement_->set_otel_attribute("ton.interfaces.committed_accounts_count", committed_detector_tasks);
+        measurement_->set_otel_attribute("ton.interfaces.detector_tasks_count", emulated_detector_tasks + committed_detector_tasks);
     }
 }
 

--- a/ton-index-worker/ton-trace-emulator/src/TraceInterfaceDetector.h
+++ b/ton-index-worker/ton-trace-emulator/src/TraceInterfaceDetector.h
@@ -8,10 +8,11 @@ private:
     std::shared_ptr<block::ConfigInfo> config_;
     Trace trace_;
     td::Promise<Trace> promise_;
+    MeasurementPtr measurement_;
 public:
     TraceInterfaceDetector(AllShardStates shard_states, std::shared_ptr<block::ConfigInfo> config,
-                           Trace trace, td::Promise<Trace> promise, const MeasurementPtr& /*measurement*/) :
-        shard_states_(shard_states), config_(config), trace_(std::move(trace)), promise_(std::move(promise)) {}
+                           Trace trace, td::Promise<Trace> promise, const MeasurementPtr& measurement) :
+        shard_states_(shard_states), config_(config), trace_(std::move(trace)), promise_(std::move(promise)), measurement_(measurement) {}
 
     void start_up() override;
 private:

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
@@ -13,52 +13,12 @@
 #include <errno.h>
 #include <chrono>
 #include <cstdint>
-#include <optional>
 
 namespace {
 constexpr const char* kHealthKey = "health:ton-trace-emulator";
 constexpr auto kHealthTtl = std::chrono::seconds(20);
 constexpr double kHealthIntervalSec = 1.0;
 constexpr std::size_t kMaxSeenSignedBlocks = 65536;
-
-std::shared_ptr<OtelStageSpan> make_read_block_span(const std::string& finality,
-                                                    std::optional<ton::BlockSeqno> mc_seqno = std::nullopt,
-                                                    std::optional<ton::BlockIdExt> block_id = std::nullopt) {
-    if (!OtelStageSpan::tracing_enabled()) {
-        return nullptr;
-    }
-
-    auto span = std::make_shared<OtelStageSpan>(OtelStageSpan::Options{
-        .service_name = "ton-trace-emulator",
-        .span_name = "ton.trace_emulator.read_block",
-        .pipeline = "trace_to_actions_to_stream",
-        .service_stage = "read_block",
-        .kind = opentelemetry::trace::SpanKind::kInternal,
-        .parent = std::nullopt,
-        .start_system_time_ns = OtelStageSpan::system_now_ns(),
-        .start_steady_time_ns = OtelStageSpan::steady_now_ns(),
-    });
-    span->set_attribute("ton.trace.finality", finality);
-    span->set_attribute("ton.trace_emulator.operation", "read_block");
-    span->set_attribute("ton.trace_emulator.source", "block");
-    if (mc_seqno) {
-        span->set_attribute("ton.mc_seqno", static_cast<std::int64_t>(*mc_seqno));
-    }
-    if (block_id) {
-        span->set_attribute("ton.block.workchain", static_cast<std::int64_t>(block_id->id.workchain));
-        span->set_attribute("ton.block.seqno", static_cast<std::int64_t>(block_id->id.seqno));
-    }
-    return span;
-}
-
-void fail_read_block_span(std::shared_ptr<OtelStageSpan>& span, const std::string& error_type, const td::Status& error) {
-    if (!span) {
-        return;
-    }
-    span->mark_error(error_type, error.to_string());
-    span->end();
-    span.reset();
-}
 }  // namespace
 
 
@@ -158,9 +118,6 @@ void TraceEmulatorScheduler::fetch_seqnos() {
     for (auto it = seqnos_to_fetch_.begin(); it != seqnos_to_fetch_.end(); ) {
         auto seqno = *it;
         LOG(INFO) << "Fetching seqno " << seqno;
-        if (auto span = make_read_block_span("finalized", std::optional<ton::BlockSeqno>(seqno))) {
-            finalized_read_block_spans_[seqno] = std::move(span);
-        }
 
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), seqno](td::Result<schema::MasterchainBlockDataState> R) {
             if (R.is_error()) {
@@ -185,20 +142,12 @@ void TraceEmulatorScheduler::fetch_seqnos() {
 
 void TraceEmulatorScheduler::fetch_error(std::uint32_t seqno, td::Status error) {
     LOG(ERROR) << "Failed to fetch seqno " << seqno << ": " << error;
-    if (auto it = finalized_read_block_spans_.find(seqno); it != finalized_read_block_spans_.end()) {
-        fail_read_block_span(it->second, "trace_emulator.read_block_error", error);
-        finalized_read_block_spans_.erase(it);
-    }
     seqnos_to_fetch_.insert(seqno);
     alarm_timestamp() = td::Timestamp::in(0.1);
 }
 
 void TraceEmulatorScheduler::seqno_fetched(std::uint32_t seqno, schema::MasterchainBlockDataState mc_data_state) {
     LOG(INFO) << "Fetched seqno " << seqno;
-    if (auto it = finalized_read_block_spans_.find(seqno); it != finalized_read_block_spans_.end() && it->second) {
-        it->second->set_attribute("ton.block.shards_count", static_cast<std::int64_t>(mc_data_state.shard_blocks_.size()));
-        it->second->set_attribute("ton.block.diff_blocks_count", static_cast<std::int64_t>(mc_data_state.shard_blocks_diff_.size()));
-    }
 
     last_finalized_mc_block_time_ = mc_data_state.shard_blocks_[0].handle->unix_time();
 
@@ -247,12 +196,7 @@ void TraceEmulatorScheduler::emulate_blocks() {
             LOG(INFO) << "Success emulating mc block " << blkid.to_str();
         });
         auto actor_name = PSLICE() << "McBlockEmulator" << last_emulated_seqno_ + 1;
-        std::shared_ptr<OtelStageSpan> read_block_span;
-        if (auto span_it = finalized_read_block_spans_.find(last_emulated_seqno_ + 1); span_it != finalized_read_block_spans_.end()) {
-            read_block_span = std::move(span_it->second);
-            finalized_read_block_spans_.erase(span_it);
-        }
-        td::actor::create_actor<McBlockEmulator>(actor_name, it->second, insert_trace_, std::move(P), std::move(read_block_span)).release();
+        td::actor::create_actor<McBlockEmulator>(actor_name, it->second, insert_trace_, std::move(P)).release();
 
         blocks_to_emulate_.erase(it);
         last_emulated_seqno_++;
@@ -265,11 +209,6 @@ void TraceEmulatorScheduler::enqueue_signed_block(ton::BlockIdExt block_id) {
         return;
     }
     signed_blocks_inflight_.insert(block_id);
-    if (auto span = make_read_block_span("confirmed",
-                                         std::nullopt,
-                                         std::optional<ton::BlockIdExt>(block_id))) {
-        signed_read_block_spans_[block_id] = std::move(span);
-    }
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<schema::BlockDataState> R) mutable {
         if (R.is_error()) {
             td::actor::send_closure(SelfId, &TraceEmulatorScheduler::signed_block_error, block_id, R.move_as_error());
@@ -285,10 +224,6 @@ void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, sche
     LOG(INFO) << "Collected signed shard block " << block_id.to_str() << " created " << td::StringBuilder::FixedDouble(time_diff, 2) << "s ago";
 
     last_confirmed_block_time_ = block_data_state.handle->unix_time();
-    if (auto it = signed_read_block_spans_.find(block_id); it != signed_read_block_spans_.end() && it->second) {
-        it->second->set_attribute("ton.block.seqno", static_cast<std::int64_t>(block_data_state.block_data->block_id().id.seqno));
-        it->second->set_attribute("ton.block.workchain", static_cast<std::int64_t>(block_data_state.block_data->block_id().id.workchain));
-    }
 
     signed_blocks_inflight_.erase(block_id);
     td::actor::send_closure(invalidated_trace_tracker_, &InvalidatedTraceTracker::register_pending_block, block_data_state.handle->id());
@@ -301,10 +236,6 @@ void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, sche
 void TraceEmulatorScheduler::signed_block_error(ton::BlockIdExt block_id, td::Status error) {
     signed_blocks_inflight_.erase(block_id);
     LOG(ERROR) << "Failed to collect signed shard block " << block_id.to_str() << ": " << error;
-    if (auto it = signed_read_block_spans_.find(block_id); it != signed_read_block_spans_.end()) {
-        fail_read_block_span(it->second, "trace_emulator.read_block_error", error);
-        signed_read_block_spans_.erase(it);
-    }
     ton::delay_action([SelfId = actor_id(this), block_id]() {
         td::actor::send_closure(SelfId, &TraceEmulatorScheduler::enqueue_signed_block, block_id);
     }, td::Timestamp::in(0.1));
@@ -343,14 +274,9 @@ void TraceEmulatorScheduler::process_signed_blocks() {
         });
         auto actor_name = PSLICE() << "SignedBlockEmulator" << block_id.seqno();
         auto trace_processor = make_signed_trace_processor(block_id);
-        std::shared_ptr<OtelStageSpan> read_block_span;
-        if (auto span_it = signed_read_block_spans_.find(block_id); span_it != signed_read_block_spans_.end()) {
-            read_block_span = std::move(span_it->second);
-            signed_read_block_spans_.erase(span_it);
-        }
         td::actor::create_actor<ConfirmedBlockEmulator>(actor_name, FinalityState::Confirmed, std::move(block_data_state), latest_config_,
                                                         std::move(shard_snapshot_copy), std::move(trace_processor),
-                                                        std::move(P), std::move(read_block_span))
+                                                        std::move(P))
             .release();
     }
 }

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
@@ -110,13 +110,15 @@ void TraceEmulatorScheduler::start_up() {
     if (global_config_path_.empty() || inet_addr_.empty()) {
         LOG(WARNING) << "Global config path or inet addr is empty. OverlayListener was not started.";
     } else {
-        overlay_listener_ = td::actor::create_actor<OverlayListener>("OverlayListener", global_config_path_, inet_addr_, insert_trace_);
+        overlay_listener_ = td::actor::create_actor<OverlayListener>("OverlayListener", global_config_path_, inet_addr_,
+                                                                     insert_trace_, external_message_admission_);
     }
 
     if (input_redis_channel_.empty()) {
         LOG(WARNING) << "Input redis queue name is empty. RedisListener was not started.";
     } else {
-        redis_listener_ = td::actor::create_actor<RedisListener>("RedisListener", redis_dsn_, input_redis_channel_, insert_trace_);
+        redis_listener_ = td::actor::create_actor<RedisListener>("RedisListener", redis_dsn_, input_redis_channel_,
+                                                                 insert_trace_, external_message_admission_);
     }
 
     if (db_event_fifo_path_.empty()) {

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
@@ -12,12 +12,53 @@
 #include <fcntl.h>
 #include <errno.h>
 #include <chrono>
+#include <cstdint>
+#include <optional>
 
 namespace {
 constexpr const char* kHealthKey = "health:ton-trace-emulator";
 constexpr auto kHealthTtl = std::chrono::seconds(20);
 constexpr double kHealthIntervalSec = 1.0;
 constexpr std::size_t kMaxSeenSignedBlocks = 65536;
+
+std::shared_ptr<OtelStageSpan> make_read_block_span(const std::string& finality,
+                                                    std::optional<ton::BlockSeqno> mc_seqno = std::nullopt,
+                                                    std::optional<ton::BlockIdExt> block_id = std::nullopt) {
+    if (!OtelStageSpan::tracing_enabled()) {
+        return nullptr;
+    }
+
+    auto span = std::make_shared<OtelStageSpan>(OtelStageSpan::Options{
+        .service_name = "ton-trace-emulator",
+        .span_name = "ton.trace_emulator.read_block",
+        .pipeline = "trace_to_actions_to_stream",
+        .service_stage = "read_block",
+        .kind = opentelemetry::trace::SpanKind::kInternal,
+        .parent = std::nullopt,
+        .start_system_time_ns = OtelStageSpan::system_now_ns(),
+        .start_steady_time_ns = OtelStageSpan::steady_now_ns(),
+    });
+    span->set_attribute("ton.trace.finality", finality);
+    span->set_attribute("ton.trace_emulator.operation", "read_block");
+    span->set_attribute("ton.trace_emulator.source", "block");
+    if (mc_seqno) {
+        span->set_attribute("ton.mc_seqno", static_cast<std::int64_t>(*mc_seqno));
+    }
+    if (block_id) {
+        span->set_attribute("ton.block.workchain", static_cast<std::int64_t>(block_id->id.workchain));
+        span->set_attribute("ton.block.seqno", static_cast<std::int64_t>(block_id->id.seqno));
+    }
+    return span;
+}
+
+void fail_read_block_span(std::shared_ptr<OtelStageSpan>& span, const std::string& error_type, const td::Status& error) {
+    if (!span) {
+        return;
+    }
+    span->mark_error(error_type, error.to_string());
+    span->end();
+    span.reset();
+}
 }  // namespace
 
 
@@ -115,6 +156,9 @@ void TraceEmulatorScheduler::fetch_seqnos() {
     for (auto it = seqnos_to_fetch_.begin(); it != seqnos_to_fetch_.end(); ) {
         auto seqno = *it;
         LOG(INFO) << "Fetching seqno " << seqno;
+        if (auto span = make_read_block_span("finalized", std::optional<ton::BlockSeqno>(seqno))) {
+            finalized_read_block_spans_[seqno] = std::move(span);
+        }
 
         auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), seqno](td::Result<schema::MasterchainBlockDataState> R) {
             if (R.is_error()) {
@@ -138,13 +182,21 @@ void TraceEmulatorScheduler::fetch_seqnos() {
 }
 
 void TraceEmulatorScheduler::fetch_error(std::uint32_t seqno, td::Status error) {
-    LOG(ERROR) << "Failed to fetch seqno " << seqno << ": " << std::move(error);
+    LOG(ERROR) << "Failed to fetch seqno " << seqno << ": " << error;
+    if (auto it = finalized_read_block_spans_.find(seqno); it != finalized_read_block_spans_.end()) {
+        fail_read_block_span(it->second, "trace_emulator.read_block_error", error);
+        finalized_read_block_spans_.erase(it);
+    }
     seqnos_to_fetch_.insert(seqno);
     alarm_timestamp() = td::Timestamp::in(0.1);
 }
 
 void TraceEmulatorScheduler::seqno_fetched(std::uint32_t seqno, schema::MasterchainBlockDataState mc_data_state) {
     LOG(INFO) << "Fetched seqno " << seqno;
+    if (auto it = finalized_read_block_spans_.find(seqno); it != finalized_read_block_spans_.end() && it->second) {
+        it->second->set_attribute("ton.block.shards_count", static_cast<std::int64_t>(mc_data_state.shard_blocks_.size()));
+        it->second->set_attribute("ton.block.diff_blocks_count", static_cast<std::int64_t>(mc_data_state.shard_blocks_diff_.size()));
+    }
 
     last_finalized_mc_block_time_ = mc_data_state.shard_blocks_[0].handle->unix_time();
 
@@ -193,7 +245,12 @@ void TraceEmulatorScheduler::emulate_blocks() {
             LOG(INFO) << "Success emulating mc block " << blkid.to_str();
         });
         auto actor_name = PSLICE() << "McBlockEmulator" << last_emulated_seqno_ + 1;
-        td::actor::create_actor<McBlockEmulator>(actor_name, it->second, insert_trace_, std::move(P)).release();
+        std::shared_ptr<OtelStageSpan> read_block_span;
+        if (auto span_it = finalized_read_block_spans_.find(last_emulated_seqno_ + 1); span_it != finalized_read_block_spans_.end()) {
+            read_block_span = std::move(span_it->second);
+            finalized_read_block_spans_.erase(span_it);
+        }
+        td::actor::create_actor<McBlockEmulator>(actor_name, it->second, insert_trace_, std::move(P), std::move(read_block_span)).release();
 
         blocks_to_emulate_.erase(it);
         last_emulated_seqno_++;
@@ -206,6 +263,11 @@ void TraceEmulatorScheduler::enqueue_signed_block(ton::BlockIdExt block_id) {
         return;
     }
     signed_blocks_inflight_.insert(block_id);
+    if (auto span = make_read_block_span("confirmed",
+                                         std::nullopt,
+                                         std::optional<ton::BlockIdExt>(block_id))) {
+        signed_read_block_spans_[block_id] = std::move(span);
+    }
     auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<schema::BlockDataState> R) mutable {
         if (R.is_error()) {
             td::actor::send_closure(SelfId, &TraceEmulatorScheduler::signed_block_error, block_id, R.move_as_error());
@@ -221,6 +283,10 @@ void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, sche
     LOG(INFO) << "Collected signed shard block " << block_id.to_str() << " created " << td::StringBuilder::FixedDouble(time_diff, 2) << "s ago";
 
     last_confirmed_block_time_ = block_data_state.handle->unix_time();
+    if (auto it = signed_read_block_spans_.find(block_id); it != signed_read_block_spans_.end() && it->second) {
+        it->second->set_attribute("ton.block.seqno", static_cast<std::int64_t>(block_data_state.block_data->block_id().id.seqno));
+        it->second->set_attribute("ton.block.workchain", static_cast<std::int64_t>(block_data_state.block_data->block_id().id.workchain));
+    }
 
     signed_blocks_inflight_.erase(block_id);
     td::actor::send_closure(invalidated_trace_tracker_, &InvalidatedTraceTracker::register_pending_block, block_data_state.handle->id());
@@ -233,6 +299,10 @@ void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, sche
 void TraceEmulatorScheduler::signed_block_error(ton::BlockIdExt block_id, td::Status error) {
     signed_blocks_inflight_.erase(block_id);
     LOG(ERROR) << "Failed to collect signed shard block " << block_id.to_str() << ": " << error;
+    if (auto it = signed_read_block_spans_.find(block_id); it != signed_read_block_spans_.end()) {
+        fail_read_block_span(it->second, "trace_emulator.read_block_error", error);
+        signed_read_block_spans_.erase(it);
+    }
     ton::delay_action([SelfId = actor_id(this), block_id]() {
         td::actor::send_closure(SelfId, &TraceEmulatorScheduler::enqueue_signed_block, block_id);
     }, td::Timestamp::in(0.1));
@@ -271,9 +341,14 @@ void TraceEmulatorScheduler::process_signed_blocks() {
         });
         auto actor_name = PSLICE() << "SignedBlockEmulator" << block_id.seqno();
         auto trace_processor = make_signed_trace_processor(block_id);
+        std::shared_ptr<OtelStageSpan> read_block_span;
+        if (auto span_it = signed_read_block_spans_.find(block_id); span_it != signed_read_block_spans_.end()) {
+            read_block_span = std::move(span_it->second);
+            signed_read_block_spans_.erase(span_it);
+        }
         td::actor::create_actor<ConfirmedBlockEmulator>(actor_name, FinalityState::Confirmed, std::move(block_data_state), latest_config_,
                                                         std::move(shard_snapshot_copy), std::move(trace_processor),
-                                                        std::move(P))
+                                                        std::move(P), std::move(read_block_span))
             .release();
     }
 }

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
@@ -42,13 +42,11 @@ class TraceEmulatorScheduler : public td::actor::Actor {
 
     std::unordered_set<ton::BlockSeqno> seqnos_to_fetch_;
     std::map<ton::BlockSeqno, schema::MasterchainBlockDataState> blocks_to_emulate_;
-    std::map<ton::BlockSeqno, std::shared_ptr<OtelStageSpan>> finalized_read_block_spans_;
     std::deque<ton::BlockIdExt> signed_block_queue_;
     std::deque<ton::BlockIdExt> seen_signed_block_order_;
     std::unordered_set<ton::BlockIdExt, BlockIdExtHasher> seen_signed_blocks_;
     std::unordered_set<ton::BlockIdExt, BlockIdExtHasher> signed_blocks_inflight_;
     std::unordered_map<ton::BlockIdExt, schema::BlockDataState, BlockIdExtHasher> signed_block_storage_;
-    std::unordered_map<ton::BlockIdExt, std::shared_ptr<OtelStageSpan>, BlockIdExtHasher> signed_read_block_spans_;
     std::shared_ptr<block::ConfigInfo> latest_config_;
     std::vector<ShardStateSnapshot> latest_shard_states_;
 

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
@@ -41,11 +41,13 @@ class TraceEmulatorScheduler : public td::actor::Actor {
 
     std::unordered_set<ton::BlockSeqno> seqnos_to_fetch_;
     std::map<ton::BlockSeqno, schema::MasterchainBlockDataState> blocks_to_emulate_;
+    std::map<ton::BlockSeqno, std::shared_ptr<OtelStageSpan>> finalized_read_block_spans_;
     std::deque<ton::BlockIdExt> signed_block_queue_;
     std::deque<ton::BlockIdExt> seen_signed_block_order_;
     std::unordered_set<ton::BlockIdExt, BlockIdExtHasher> seen_signed_blocks_;
     std::unordered_set<ton::BlockIdExt, BlockIdExtHasher> signed_blocks_inflight_;
     std::unordered_map<ton::BlockIdExt, schema::BlockDataState, BlockIdExtHasher> signed_block_storage_;
+    std::unordered_map<ton::BlockIdExt, std::shared_ptr<OtelStageSpan>, BlockIdExtHasher> signed_read_block_spans_;
     std::shared_ptr<block::ConfigInfo> latest_config_;
     std::vector<ShardStateSnapshot> latest_shard_states_;
 

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
@@ -15,6 +15,7 @@
 #include "TraceInserter.h"
 #include "BlockEmulator.h"
 #include "IndexData.h"
+#include "ExternalMessageAdmission.h"
 #include "InvalidatedTraceTracker.h"
 #include "auto/tl/ton_api.h"
 #include "DbEventListener.h"
@@ -53,6 +54,7 @@ class TraceEmulatorScheduler : public td::actor::Actor {
 
     td::actor::ActorOwn<OverlayListener> overlay_listener_;
     td::actor::ActorOwn<RedisListener> redis_listener_;
+    std::shared_ptr<ExternalMessageAdmission> external_message_admission_;
     td::actor::ActorOwn<ITraceInsertManager> insert_manager_;
     td::actor::ActorOwn<InvalidatedTraceTracker> invalidated_trace_tracker_;
     std::unique_ptr<sw::redis::Redis> health_redis_;
@@ -91,6 +93,7 @@ class TraceEmulatorScheduler : public td::actor::Actor {
       insert_trace_ = [insert_manager = insert_manager_.get()](Trace trace, td::Promise<td::Unit> promise, MeasurementPtr measurement) {
         td::actor::send_closure(insert_manager, &ITraceInsertManager::insert, std::move(trace), std::move(promise), measurement);
       };
+      external_message_admission_ = std::make_shared<ExternalMessageAdmission>();
       invalidated_trace_tracker_ = td::actor::create_actor<InvalidatedTraceTracker>("InvalidatedTraceTracker", redis_dsn_);
     };
 

--- a/ton-index-worker/ton-trace-task-emulator/CMakeLists.txt
+++ b/ton-index-worker/ton-trace-task-emulator/CMakeLists.txt
@@ -11,7 +11,7 @@ target_include_directories(ton-trace-task-emulator
     PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../external/redis-plus-plus/src
 )
 target_compile_features(ton-trace-task-emulator PRIVATE cxx_std_20)
-target_link_libraries(ton-trace-task-emulator ton-trace-emulator-core hiredis redis++_static msgpack-cxx)
+target_link_libraries(ton-trace-task-emulator ton-trace-emulator-core redis++_static msgpack-cxx)
 target_link_options(ton-trace-task-emulator PUBLIC -rdynamic)
 target_compile_definitions(ton-trace-task-emulator PRIVATE -DMSGPACK_USE_DEFINE_MAP)
 install(TARGETS ton-trace-task-emulator RUNTIME DESTINATION bin)


### PR DESCRIPTION
- add child spans of ton-trace-emulator.process
- confirmed block deduplication
- rate limit and deduplication for redis and overlay listeners
- link hiredis statically
- flushdb redis during deployment