### PR TITLE
Streaming API fixes

### DIFF
--- a/deploy-pendings.yaml
+++ b/deploy-pendings.yaml
@@ -205,11 +205,26 @@
         line: "maxclients 100000"
       register: redis_maxclients_config
 
-    - name: Restart Redis after maxclients change
+    - name: Comment Redis RDB save rules
+      ansible.builtin.replace:
+        path: /etc/redis/redis.conf
+        regexp: '^(?!\s*#)(\s*save\s+(?!""\s*(?:#.*)?$).*)$'
+        replace: '# \1'
+      register: redis_save_rules_commented
+
+    - name: Disable Redis RDB snapshots
+      ansible.builtin.lineinfile:
+        path: /etc/redis/redis.conf
+        regexp: '^\s*#?\s*save\s+""\s*(?:#.*)?$'
+        line: 'save ""'
+        insertafter: '^#?\s*save\s+'
+      register: redis_save_disabled
+
+    - name: Restart Redis after config change
       ansible.builtin.systemd:
         name: redis-server
         state: restarted
-      when: redis_maxclients_config.changed
+      when: redis_maxclients_config.changed or redis_save_rules_commented.changed or redis_save_disabled.changed
 
     - name: Stop pendings services before Redis flush
       ansible.builtin.systemd:

--- a/ton-index-worker/ton-trace-emulator/src/TraceInserter.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceInserter.cpp
@@ -7,6 +7,9 @@
 
 namespace {
 
+constexpr bool kPipelineTransactionCommands = false;
+constexpr bool kCreateDedicatedTransactionConnection = false;
+
 std::string finality_name(FinalityState finality) {
     switch (finality) {
         case FinalityState::Emulated:
@@ -319,5 +322,10 @@ public:
 };
 
 void RedisInsertManager::insert(Trace trace, td::Promise<td::Unit> promise, MeasurementPtr measurement) {
-    td::actor::create_actor<TraceInserter>("TraceInserter", redis_.transaction(), std::move(trace), std::move(promise), measurement).release();
+    td::actor::create_actor<TraceInserter>(
+        "TraceInserter",
+        redis_.transaction(kPipelineTransactionCommands, kCreateDedicatedTransactionConnection),
+        std::move(trace),
+        std::move(promise),
+        measurement).release();
 }

--- a/ton-streaming-go/v1/server.go
+++ b/ton-streaming-go/v1/server.go
@@ -658,7 +658,9 @@ func ProcessNewClassifiedTrace(ctx context.Context, rdb *redis.Client, traceExte
 	}
 }
 
-// SubscribeToTraces subscribes to blockchain events from Redis
+// SubscribeToTraces subscribes to trace updates from Redis.
+// The producer publishes every trace insertion/update to this channel, so this
+// path must extract only pending transactions before broadcasting.
 func SubscribeToTraces(ctx context.Context, rdb *redis.Client, manager *ClientManager, channel string) {
 	pubsub := rdb.Subscribe(ctx, channel)
 	defer pubsub.Close()
@@ -814,9 +816,15 @@ func ProcessNewTrace(ctx context.Context, rdb *redis.Client, traceExternalHashNo
 	{
 		emulatedTxs := emulatedContext.GetTransactions()
 		for _, tx := range emulatedTxs {
+			if tx.Finality != indexModels.FinalityStatePending {
+				continue
+			}
 			txs = append(txs, *tx)
 			txs_map[tx.Hash] = len(txs) - 1
 		}
+	}
+	if len(txs) == 0 {
+		return
 	}
 
 	allAddresses := []string{}

--- a/ton-streaming-go/v2/server.go
+++ b/ton-streaming-go/v2/server.go
@@ -835,19 +835,21 @@ func (n *JettonsNotification) AdjustForClient(client *Client) any {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-// Redis subscription: traces (pending)
+// Redis subscription: trace updates.
+// The producer publishes every trace insertion/update to this channel, so this
+// path must extract only pending transactions before broadcasting.
 ////////////////////////////////////////////////////////////////////////////////
 
 func SubscribeToTraces(ctx context.Context, rdb *redis.Client, manager *ClientManager, channel string) {
 	pubsub := rdb.Subscribe(ctx, channel)
 	defer pubsub.Close()
 
-	log.Printf("[v2] Subscribed to Redis channel (pending traces): %s", channel)
+	log.Printf("[v2] Subscribed to Redis channel (trace updates): %s", channel)
 
 	for {
 		msg, err := pubsub.ReceiveMessage(ctx)
 		if err != nil {
-			log.Printf("[v2] Error receiving pending trace message: %v", err)
+			log.Printf("[v2] Error receiving trace update message: %v", err)
 			continue
 		}
 		traceExternalHashNorm := msg.Payload
@@ -855,7 +857,7 @@ func SubscribeToTraces(ctx context.Context, rdb *redis.Client, manager *ClientMa
 	}
 }
 
-// pending (emulated) trace
+// ProcessNewTrace broadcasts pending transactions from a generic trace update.
 func ProcessNewTrace(ctx context.Context, rdb *redis.Client, traceExternalHashNorm string, manager *ClientManager, channel string) {
 	startTimeUnix := observability.NowUnixNano()
 	repository := &emulated.EmulatedTracesRepository{Rdb: rdb}
@@ -892,15 +894,29 @@ func ProcessNewTrace(ctx context.Context, rdb *redis.Client, traceExternalHashNo
 
 	var txs []indexModels.Transaction
 	txsMap := map[indexModels.HashType]int{}
+	totalTxs := 0
 	{
 		emulatedTxs := emulatedContext.GetTransactions()
 		for _, tx := range emulatedTxs {
+			totalTxs++
+			if tx.Finality != indexModels.FinalityStatePending {
+				continue
+			}
 			txs = append(txs, *tx)
 			txsMap[tx.Hash] = len(txs) - 1
 			if stage.RootTxHash == "-" && tx.TraceId != nil {
 				stage.SetRootTxHash(*tx.TraceId)
 			}
 		}
+	}
+	if len(txs) == 0 {
+		stage.Span.AddAttr("ton.trace.finality", indexModels.FinalityStatePending.String())
+		stage.Span.AddAttr("ton.transactions.count", 0)
+		stage.Span.AddAttr("ton.transactions.total_count", totalTxs)
+		stage.Span.AddAttr("ton.streaming.skipped", true)
+		stage.Span.AddAttr("ton.streaming.skip_reason", "no_pending_transactions")
+		stage.Emit()
+		return
 	}
 
 	allAddresses := []string{}
@@ -970,6 +986,7 @@ func ProcessNewTrace(ctx context.Context, rdb *redis.Client, traceExternalHashNo
 	})
 	stage.Span.AddAttr("ton.trace.finality", indexModels.FinalityStatePending.String())
 	stage.Span.AddAttr("ton.transactions.count", len(txs))
+	stage.Span.AddAttr("ton.transactions.total_count", totalTxs)
 
 	manager.broadcast <- &TransactionsNotification{
 		Type:                  EventTransactions,


### PR DESCRIPTION
- Fix connection pooling in ton-trace-emulator
- Fix streaming pending tx handling for generic new_trace updates
- Disable RDB snapshots