### PR TITLE
trace-emulator: limit event processing concurrency

### DIFF
--- a/ton-index-worker/ton-trace-emulator/src/BlockEmulator.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/BlockEmulator.cpp
@@ -335,6 +335,7 @@ void McBlockEmulator::emulate_traces(MeasurementPtr measurement) {
 
         td::actor::create_actor<MasterchainBlockEmulator>("MasterchainBlockEmulator", context_ref, std::move(msgs_to_emulate), std::move(P), tx_measurement).release();
     }
+    finish_block_if_done();
 }
 
 void McBlockEmulator::children_emulated(std::unique_ptr<TraceNode> parent_node,
@@ -392,6 +393,7 @@ void McBlockEmulator::trace_error(td::Bits256 tx_hash, td::Bits256 trace_root_tx
     measurement->end_otel_child_span("emulate_tail");
     in_progress_cnt_--;
     measurement->emit_otel_span();
+    finish_block_if_done();
 }
 
 void McBlockEmulator::trace_interfaces_error(td::Bits256 trace_root_tx_hash, td::Status error, MeasurementPtr measurement) {
@@ -400,6 +402,7 @@ void McBlockEmulator::trace_interfaces_error(td::Bits256 trace_root_tx_hash, td:
     measurement->end_otel_child_span("detect_interfaces");
     in_progress_cnt_--;
     measurement->emit_otel_span();
+    finish_block_if_done();
 }
 
 void McBlockEmulator::trace_emulated(Trace trace, MeasurementPtr measurement) {
@@ -424,12 +427,18 @@ void McBlockEmulator::trace_finished(td::Bits256, MeasurementPtr measurement) {
     traces_cnt_++;
     measurement->emit_otel_span();
 
-    if (in_progress_cnt_ == 0) {
-        auto blkid = mc_data_state_.shard_blocks_[0].block_data->block_id().id;
-        LOG(INFO) << "Finished emulating block " << blkid.to_str() << ": " << traces_cnt_ << " traces in " << (td::Timestamp::now().at() - start_time_.at()) * 1000 << " ms";
-        promise_.set_value(td::Unit());
-        stop();
+    finish_block_if_done();
+}
+
+void McBlockEmulator::finish_block_if_done() {
+    if (finished_ || in_progress_cnt_ != 0) {
+        return;
     }
+    finished_ = true;
+    auto blkid = mc_data_state_.shard_blocks_[0].block_data->block_id().id;
+    LOG(INFO) << "Finished emulating block " << blkid.to_str() << ": " << traces_cnt_ << " traces in " << (td::Timestamp::now().at() - start_time_.at()) * 1000 << " ms";
+    promise_.set_value(td::Unit());
+    stop();
 }
 
 void ConfirmedBlockEmulator::start_up() {

--- a/ton-index-worker/ton-trace-emulator/src/BlockEmulator.h
+++ b/ton-index-worker/ton-trace-emulator/src/BlockEmulator.h
@@ -61,6 +61,7 @@ private:
     size_t in_progress_cnt_{0};
 
     int traces_cnt_{0};
+    bool finished_{false};
 
     td::Timestamp start_time_;
 
@@ -79,6 +80,7 @@ private:
     void trace_interfaces_error(td::Bits256 trace_root_tx_hash, td::Status error, MeasurementPtr measurement);
     void trace_emulated(Trace trace, MeasurementPtr measurement);
     void trace_finished(td::Bits256, MeasurementPtr measurement);
+    void finish_block_if_done();
 
 public:
     McBlockEmulator(schema::MasterchainBlockDataState mc_data_state,

--- a/ton-index-worker/ton-trace-emulator/src/DbEventListener.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/DbEventListener.cpp
@@ -1,6 +1,14 @@
 #include "DbEventListener.h"
 #include "TraceScheduler.h"
 
+namespace {
+constexpr std::size_t kReadChunkSize = 4096;
+constexpr std::size_t kMaxReadChunksPerAlarm = 64;
+constexpr std::size_t kMaxEventsPerAlarm = 1024;
+constexpr double kBusyPollDelaySec = 0.001;
+constexpr double kIdlePollDelaySec = 0.05;
+}  // namespace
+
 
 void DbEventListener::start_up() {
     alarm_timestamp() = td::Timestamp::now();
@@ -12,22 +20,31 @@ void DbEventListener::alarm() {
         return;
     }
 
-    char chunk[4096];
-    while (true) {
+    char chunk[kReadChunkSize];
+    std::size_t chunks_read = 0;
+    std::size_t events_processed = process_buffer(kMaxEventsPerAlarm);
+    bool made_progress = events_processed > 0;
+
+    while (chunks_read < kMaxReadChunksPerAlarm && events_processed < kMaxEventsPerAlarm) {
         auto bytes_read = ::read(fd_, chunk, sizeof(chunk));
         if (bytes_read > 0) {
+            made_progress = true;
+            chunks_read++;
             buffer_.append(chunk, static_cast<size_t>(bytes_read));
-            process_buffer();
+            events_processed += process_buffer(kMaxEventsPerAlarm - events_processed);
             continue;
         }
 
         if (bytes_read == 0) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(3));
-            continue;
+            break;
         }
 
         if (errno == EINTR) {
             continue;
+        }
+
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            break;
         }
 
         LOG(ERROR) << "Failed to read DB events FIFO '" << path_ << "': "
@@ -37,6 +54,8 @@ void DbEventListener::alarm() {
         alarm_timestamp() = td::Timestamp::in(0.1);
         return;
     }
+
+    alarm_timestamp() = td::Timestamp::in(made_progress ? kBusyPollDelaySec : kIdlePollDelaySec);
 #else
     stop();
 #endif
@@ -53,15 +72,12 @@ bool DbEventListener::ensure_open() {
         alarm_timestamp() = td::Timestamp::in(0.5);
         return false;
     }
-    auto flags = fcntl(fd_, F_GETFL, 0);
-    if (flags >= 0) {
-        fcntl(fd_, F_SETFL, flags & ~O_NONBLOCK);
-    }
     return true;
 }
 
-void DbEventListener::process_buffer() {
-    while (true) {
+std::size_t DbEventListener::process_buffer(std::size_t max_events) {
+    std::size_t processed = 0;
+    while (processed < max_events) {
         td::Slice slice(buffer_);
         auto parsed = ton::fetch_tl_prefix<ton::ton_api::db_Event>(slice, true);
         if (parsed.is_error()) {
@@ -79,5 +95,7 @@ void DbEventListener::process_buffer() {
         auto consumed = buffer_.size() - slice.size();
         buffer_.erase(0, consumed);
         td::actor::send_closure(consumer_, &TraceEmulatorScheduler::handle_db_event, parsed.move_as_ok());
+        processed++;
     }
+    return processed;
 }

--- a/ton-index-worker/ton-trace-emulator/src/DbEventListener.h
+++ b/ton-index-worker/ton-trace-emulator/src/DbEventListener.h
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <cstddef>
 
 
 class TraceEmulatorScheduler;
@@ -28,5 +29,5 @@ class DbEventListener : public td::actor::Actor {
 
     bool ensure_open();
 
-    void process_buffer();
+    std::size_t process_buffer(std::size_t max_events);
 };

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
@@ -19,6 +19,9 @@ constexpr const char* kHealthKey = "health:ton-trace-emulator";
 constexpr auto kHealthTtl = std::chrono::seconds(20);
 constexpr double kHealthIntervalSec = 1.0;
 constexpr std::size_t kMaxSeenSignedBlocks = 65536;
+constexpr std::size_t kMaxFinalizedBlocksInFlight = 2;
+constexpr std::size_t kMaxConfirmedBlocksInFlight = 8;
+constexpr std::size_t kMaxSignedBlockFetchesInFlight = 64;
 }  // namespace
 
 
@@ -28,11 +31,11 @@ void TraceEmulatorScheduler::handle_db_event(ton::tl_object_ptr<ton::ton_api::db
                     [&](ton::ton_api::db_event_blockCandidateReceived &ev) {
                     },
                     [&](ton::ton_api::db_event_blockApplied &ev) {
-                        LOG(WARNING) << "db_event_blockApplied: "<< ton::create_block_id(ev.block_id_).to_str();
+                        LOG(DEBUG) << "db_event_blockApplied: "<< ton::create_block_id(ev.block_id_).to_str();
                         handle_block_applied(ton::create_block_id(ev.block_id_));
                     },
                     [&](ton::ton_api::db_event_blockSigned &ev) {
-                        LOG(WARNING) << "db_event_blockSigned: " << ton::create_block_id(ev.block_id_).to_str();
+                        LOG(DEBUG) << "db_event_blockSigned: " << ton::create_block_id(ev.block_id_).to_str();
                         handle_block_signed(ton::create_block_id(ev.block_id_));
                     }));
 }
@@ -45,22 +48,85 @@ void TraceEmulatorScheduler::handle_block_signed(ton::BlockIdExt block_id) {
         LOG(INFO) << "Skipping duplicate signed shard block " << block_id.to_str();
         return;
     }
-    auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<td::Unit> R) {
-        R.ensure();
-        td::actor::send_closure(SelfId, &TraceEmulatorScheduler::enqueue_signed_block, block_id);
-    });
-    td::actor::send_closure(db_scanner_, &DbScanner::request_catch_up, std::move(P));
+    pending_signed_blocks_.push_back(block_id);
+    request_db_catch_up();
 }
 
 void TraceEmulatorScheduler::handle_block_applied(ton::BlockIdExt block_id) {
     if (!block_id.is_masterchain()) {
         return;
     }
-    auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<td::Unit> R) {
-        R.ensure();
-        td::actor::send_closure(SelfId, &TraceEmulatorScheduler::got_last_mc_seqno, block_id.seqno());
+    if (!pending_applied_mc_seqno_ || block_id.seqno() > *pending_applied_mc_seqno_) {
+        pending_applied_mc_seqno_ = block_id.seqno();
+    }
+    request_db_catch_up();
+}
+
+bool TraceEmulatorScheduler::has_pending_db_events() const {
+    return pending_applied_mc_seqno_.has_value() || !pending_signed_blocks_.empty();
+}
+
+bool TraceEmulatorScheduler::has_ready_finalized_block() const {
+    if (last_emulated_seqno_ == 0) {
+        return false;
+    }
+    return blocks_to_emulate_.find(last_emulated_seqno_ + 1) != blocks_to_emulate_.end();
+}
+
+void TraceEmulatorScheduler::request_db_catch_up() {
+    if (db_catch_up_in_progress_ || !has_pending_db_events()) {
+        return;
+    }
+
+    db_catch_up_in_progress_ = true;
+    catch_up_applied_mc_seqno_ = pending_applied_mc_seqno_;
+    pending_applied_mc_seqno_.reset();
+    catch_up_signed_blocks_ = std::move(pending_signed_blocks_);
+    pending_signed_blocks_.clear();
+
+    auto P = td::PromiseCreator::lambda([SelfId = actor_id(this)](td::Result<td::Unit> R) mutable {
+        td::actor::send_closure(SelfId, &TraceEmulatorScheduler::db_catch_up_finished, std::move(R));
     });
     td::actor::send_closure(db_scanner_, &DbScanner::request_catch_up, std::move(P));
+}
+
+void TraceEmulatorScheduler::requeue_catch_up_batch() {
+    if (catch_up_applied_mc_seqno_) {
+        if (!pending_applied_mc_seqno_ || *catch_up_applied_mc_seqno_ > *pending_applied_mc_seqno_) {
+            pending_applied_mc_seqno_ = *catch_up_applied_mc_seqno_;
+        }
+        catch_up_applied_mc_seqno_.reset();
+    }
+    while (!catch_up_signed_blocks_.empty()) {
+        pending_signed_blocks_.push_front(catch_up_signed_blocks_.back());
+        catch_up_signed_blocks_.pop_back();
+    }
+}
+
+void TraceEmulatorScheduler::process_catch_up_batch() {
+    if (catch_up_applied_mc_seqno_) {
+        got_last_mc_seqno(*catch_up_applied_mc_seqno_);
+        catch_up_applied_mc_seqno_.reset();
+    }
+
+    while (!catch_up_signed_blocks_.empty()) {
+        auto block_id = catch_up_signed_blocks_.front();
+        catch_up_signed_blocks_.pop_front();
+        enqueue_signed_block(block_id);
+    }
+}
+
+void TraceEmulatorScheduler::db_catch_up_finished(td::Result<td::Unit> result) {
+    db_catch_up_in_progress_ = false;
+    if (result.is_error()) {
+        LOG(ERROR) << "Failed to catch up DB before processing events: " << result.move_as_error();
+        requeue_catch_up_batch();
+        alarm_timestamp() = td::Timestamp::in(0.1);
+        return;
+    }
+
+    process_catch_up_batch();
+    request_db_catch_up();
 }
 
 
@@ -178,6 +244,7 @@ void TraceEmulatorScheduler::seqno_fetched(std::uint32_t seqno, schema::Masterch
 
     blocks_to_emulate_[seqno] = mc_data_state;
     emulate_blocks();
+    process_signed_blocks();
 }
 
 void TraceEmulatorScheduler::emulate_blocks() {
@@ -186,16 +253,19 @@ void TraceEmulatorScheduler::emulate_blocks() {
     }
 
     auto it = blocks_to_emulate_.find(last_emulated_seqno_ + 1);
-    while(it != blocks_to_emulate_.end()) {
-        LOG(ERROR) << "Emulating mc block " << last_emulated_seqno_ + 1;
-        auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), blkid = it->second.shard_blocks_[0].block_data->block_id().id](td::Result<> R) {
+    while(it != blocks_to_emulate_.end() && finalized_blocks_inflight_ < kMaxFinalizedBlocksInFlight) {
+        auto seqno = last_emulated_seqno_ + 1;
+        LOG(INFO) << "Emulating mc block " << seqno;
+        finalized_blocks_inflight_++;
+        auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), seqno, blkid = it->second.shard_blocks_[0].block_data->block_id().id](td::Result<> R) {
             if (R.is_error()) {
                 LOG(ERROR) << "Error emulating mc block " << blkid.to_str();
-                return;
+            } else {
+                LOG(INFO) << "Success emulating mc block " << blkid.to_str();
             }
-            LOG(INFO) << "Success emulating mc block " << blkid.to_str();
+            td::actor::send_closure(SelfId, &TraceEmulatorScheduler::finalized_block_finished, seqno);
         });
-        auto actor_name = PSLICE() << "McBlockEmulator" << last_emulated_seqno_ + 1;
+        auto actor_name = PSLICE() << "McBlockEmulator" << seqno;
         td::actor::create_actor<McBlockEmulator>(actor_name, it->second, insert_trace_, std::move(P)).release();
 
         blocks_to_emulate_.erase(it);
@@ -204,19 +274,40 @@ void TraceEmulatorScheduler::emulate_blocks() {
     }
 }
 
+void TraceEmulatorScheduler::finalized_block_finished(ton::BlockSeqno) {
+    if (finalized_blocks_inflight_ > 0) {
+        finalized_blocks_inflight_--;
+    }
+    emulate_blocks();
+    process_signed_blocks();
+}
+
 void TraceEmulatorScheduler::enqueue_signed_block(ton::BlockIdExt block_id) {
     if (signed_blocks_inflight_.count(block_id) != 0 || signed_block_storage_.count(block_id) != 0) {
         return;
     }
-    signed_blocks_inflight_.insert(block_id);
-    auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<schema::BlockDataState> R) mutable {
-        if (R.is_error()) {
-            td::actor::send_closure(SelfId, &TraceEmulatorScheduler::signed_block_error, block_id, R.move_as_error());
-            return;
+    signed_blocks_to_fetch_queue_.push_back(block_id);
+    fetch_signed_blocks();
+}
+
+void TraceEmulatorScheduler::fetch_signed_blocks() {
+    while (!signed_blocks_to_fetch_queue_.empty() &&
+           signed_blocks_inflight_.size() < kMaxSignedBlockFetchesInFlight) {
+        auto block_id = signed_blocks_to_fetch_queue_.front();
+        signed_blocks_to_fetch_queue_.pop_front();
+        if (signed_blocks_inflight_.count(block_id) != 0 || signed_block_storage_.count(block_id) != 0) {
+            continue;
         }
-        td::actor::send_closure(SelfId, &TraceEmulatorScheduler::signed_block_fetched, block_id, R.move_as_ok());
-    });
-    td::actor::send_closure(db_scanner_, &DbScanner::fetch_block_by_id, block_id, std::move(P));
+        signed_blocks_inflight_.insert(block_id);
+        auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<schema::BlockDataState> R) mutable {
+            if (R.is_error()) {
+                td::actor::send_closure(SelfId, &TraceEmulatorScheduler::signed_block_error, block_id, R.move_as_error());
+                return;
+            }
+            td::actor::send_closure(SelfId, &TraceEmulatorScheduler::signed_block_fetched, block_id, R.move_as_ok());
+        });
+        td::actor::send_closure(db_scanner_, &DbScanner::fetch_block_by_id, block_id, std::move(P));
+    }
 }
 
 void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, schema::BlockDataState block_data_state) {
@@ -226,6 +317,7 @@ void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, sche
     last_confirmed_block_time_ = block_data_state.handle->unix_time();
 
     signed_blocks_inflight_.erase(block_id);
+    fetch_signed_blocks();
     td::actor::send_closure(invalidated_trace_tracker_, &InvalidatedTraceTracker::register_pending_block, block_data_state.handle->id());
     signed_block_storage_.emplace(block_id, std::move(block_data_state));
     signed_block_queue_.push_back(block_id);
@@ -235,6 +327,7 @@ void TraceEmulatorScheduler::signed_block_fetched(ton::BlockIdExt block_id, sche
 
 void TraceEmulatorScheduler::signed_block_error(ton::BlockIdExt block_id, td::Status error) {
     signed_blocks_inflight_.erase(block_id);
+    fetch_signed_blocks();
     LOG(ERROR) << "Failed to collect signed shard block " << block_id.to_str() << ": " << error;
     ton::delay_action([SelfId = actor_id(this), block_id]() {
         td::actor::send_closure(SelfId, &TraceEmulatorScheduler::enqueue_signed_block, block_id);
@@ -242,7 +335,11 @@ void TraceEmulatorScheduler::signed_block_error(ton::BlockIdExt block_id, td::St
 }
 
 void TraceEmulatorScheduler::process_signed_blocks() {
-    while (!signed_block_queue_.empty()) {
+    if (finalized_blocks_inflight_ > 0 || has_ready_finalized_block()) {
+        emulate_blocks();
+        return;
+    }
+    while (!signed_block_queue_.empty() && confirmed_blocks_inflight_ < kMaxConfirmedBlocksInFlight) {
         auto block_id = signed_block_queue_.front();
         signed_block_queue_.pop_front();
         auto it = signed_block_storage_.find(block_id);
@@ -267,10 +364,12 @@ void TraceEmulatorScheduler::process_signed_blocks() {
             }
         }
 
-        auto P = td::PromiseCreator::lambda([block_id](td::Result<> R) mutable {
+        confirmed_blocks_inflight_++;
+        auto P = td::PromiseCreator::lambda([SelfId = actor_id(this), block_id](td::Result<> R) mutable {
             if (R.is_error()) {
                 LOG(ERROR) << "Error processing signed shard block " << block_id.to_str() << ": " << R.move_as_error();
             }
+            td::actor::send_closure(SelfId, &TraceEmulatorScheduler::confirmed_block_finished, block_id);
         });
         auto actor_name = PSLICE() << "SignedBlockEmulator" << block_id.seqno();
         auto trace_processor = make_signed_trace_processor(block_id);
@@ -279,6 +378,13 @@ void TraceEmulatorScheduler::process_signed_blocks() {
                                                         std::move(P))
             .release();
     }
+}
+
+void TraceEmulatorScheduler::confirmed_block_finished(ton::BlockIdExt) {
+    if (confirmed_blocks_inflight_ > 0) {
+        confirmed_blocks_inflight_--;
+    }
+    process_signed_blocks();
 }
 
 bool TraceEmulatorScheduler::remember_seen_signed_block(ton::BlockIdExt block_id) {
@@ -356,6 +462,8 @@ void TraceEmulatorScheduler::alarm() {
     }
     fetch_seqnos();
     if (!db_event_fifo_path_.empty()) {
+        request_db_catch_up();
+        fetch_signed_blocks();
         process_signed_blocks();
     }
 

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <functional>
 #include <cstdint>
+#include <optional>
 #include "td/actor/actor.h"
 #include "DbScanner.h"
 #include "OverlayListener.h"
@@ -42,6 +43,7 @@ class TraceEmulatorScheduler : public td::actor::Actor {
 
     std::unordered_set<ton::BlockSeqno> seqnos_to_fetch_;
     std::map<ton::BlockSeqno, schema::MasterchainBlockDataState> blocks_to_emulate_;
+    std::deque<ton::BlockIdExt> signed_blocks_to_fetch_queue_;
     std::deque<ton::BlockIdExt> signed_block_queue_;
     std::deque<ton::BlockIdExt> seen_signed_block_order_;
     std::unordered_set<ton::BlockIdExt, BlockIdExtHasher> seen_signed_blocks_;
@@ -59,19 +61,35 @@ class TraceEmulatorScheduler : public td::actor::Actor {
     td::Timestamp next_health_update_;
     std::uint32_t last_finalized_mc_block_time_{0};
     std::uint32_t last_confirmed_block_time_{0};
+    std::optional<ton::BlockSeqno> pending_applied_mc_seqno_;
+    std::deque<ton::BlockIdExt> pending_signed_blocks_;
+    std::optional<ton::BlockSeqno> catch_up_applied_mc_seqno_;
+    std::deque<ton::BlockIdExt> catch_up_signed_blocks_;
+    bool db_catch_up_in_progress_{false};
+    std::size_t finalized_blocks_inflight_{0};
+    std::size_t confirmed_blocks_inflight_{0};
 
     void handle_block_signed(ton::BlockIdExt block_id);
     void handle_block_applied(ton::BlockIdExt block_id);
+    void request_db_catch_up();
+    bool has_pending_db_events() const;
+    bool has_ready_finalized_block() const;
+    void db_catch_up_finished(td::Result<td::Unit> result);
+    void requeue_catch_up_batch();
+    void process_catch_up_batch();
 
     void got_last_mc_seqno(ton::BlockSeqno last_known_seqno);
     void fetch_seqnos();
     void fetch_error(std::uint32_t seqno, td::Status error);
     void seqno_fetched(std::uint32_t seqno, schema::MasterchainBlockDataState mc_data_state);
     void emulate_blocks();
+    void finalized_block_finished(ton::BlockSeqno seqno);
     void enqueue_signed_block(ton::BlockIdExt block_id);
+    void fetch_signed_blocks();
     void signed_block_fetched(ton::BlockIdExt block_id, schema::BlockDataState block_data_state);
     void signed_block_error(ton::BlockIdExt block_id, td::Status error);
     void process_signed_blocks();
+    void confirmed_block_finished(ton::BlockIdExt block_id);
     bool remember_seen_signed_block(ton::BlockIdExt block_id);
     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> make_signed_trace_processor(const ton::BlockIdExt& block_id_ext);
     std::function<void(Trace, td::Promise<td::Unit>, MeasurementPtr)> make_finalized_trace_processor(const schema::MasterchainBlockDataState& mc_data_state);

--- a/ton-index-worker/tondb-scanner/src/DbScanner.cpp
+++ b/ton-index-worker/tondb-scanner/src/DbScanner.cpp
@@ -344,18 +344,51 @@ void DbScanner::request_catch_up(td::Promise<td::Unit> promise) {
     promise.set_error(td::Status::Error("cannot catch up in readonly mode"));
     return;
   }
-  catch_up_with_primary(std::move(promise));
+  if (catch_up_in_progress_) {
+    pending_catch_up_promises_.push_back(std::move(promise));
+    return;
+  }
+  catch_up_promises_.push_back(std::move(promise));
+  start_catch_up_with_primary();
 }
 
-void DbScanner::catch_up_with_primary(td::Promise<td::Unit> promise) {
-  auto R = td::PromiseCreator::lambda([SelfId = actor_id(this), this, timer = td::Timer{}, p = std::move(promise)](td::Result<td::Unit> R) mutable {
-    R.ensure();
-    p.set_value(td::Unit());
-    this->is_ready_ = true;
-    timer.pause();
-    g_statistics.record_time(CATCH_UP_WITH_PRIMARY, timer.elapsed() * 1e3);
+void DbScanner::start_catch_up_with_primary() {
+  if (catch_up_in_progress_ || catch_up_promises_.empty()) {
+    return;
+  }
+  catch_up_in_progress_ = true;
+  auto R = td::PromiseCreator::lambda([SelfId = actor_id(this), timer = td::Timer{}](td::Result<td::Unit> R) mutable {
+    auto elapsed_ms = timer.elapsed() * 1e3;
+    td::actor::send_closure(SelfId, &DbScanner::catch_up_finished, std::move(R), elapsed_ms);
   });
   td::actor::send_closure(db_, &RootDb::try_catch_up_with_primary, std::move(R));
+}
+
+void DbScanner::catch_up_finished(td::Result<td::Unit> result, double elapsed_ms) {
+  catch_up_in_progress_ = false;
+  g_statistics.record_time(CATCH_UP_WITH_PRIMARY, elapsed_ms);
+
+  auto promises = std::move(catch_up_promises_);
+  catch_up_promises_.clear();
+
+  if (result.is_error()) {
+    auto error = result.move_as_error();
+    auto error_message = error.to_string();
+    for (auto& promise : promises) {
+      promise.set_error(td::Status::Error(error_message));
+    }
+  } else {
+    is_ready_ = true;
+    for (auto& promise : promises) {
+      promise.set_value(td::Unit());
+    }
+  }
+
+  if (!pending_catch_up_promises_.empty()) {
+    catch_up_promises_ = std::move(pending_catch_up_promises_);
+    pending_catch_up_promises_.clear();
+    start_catch_up_with_primary();
+  }
 }
 
 void DbScanner::fetch_seqno(std::uint32_t mc_seqno, td::Promise<schema::MasterchainBlockDataState> promise) {
@@ -375,5 +408,5 @@ void DbScanner::alarm() {
     R.ensure();
   });
 
-  td::actor::send_closure(actor_id(this), &DbScanner::catch_up_with_primary, std::move(P));
+  request_catch_up(std::move(P));
 }

--- a/ton-index-worker/tondb-scanner/src/DbScanner.h
+++ b/ton-index-worker/tondb-scanner/src/DbScanner.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <queue>
 #include <functional>
+#include <vector>
 #include "validator/manager-disk.h"
 #include "validator/db/rootdb.hpp"
 
@@ -18,6 +19,9 @@ private:
   float catch_up_interval_;
   bool is_ready_ = false;
   ton::BlockSeqno last_known_seqno_{0};
+  bool catch_up_in_progress_{false};
+  std::vector<td::Promise<td::Unit>> catch_up_promises_;
+  std::vector<td::Promise<td::Unit>> pending_catch_up_promises_;
 
   td::actor::ActorOwn<ton::validator::ValidatorManagerInterface> validator_manager_;
   td::actor::ActorOwn<ton::validator::RootDb> db_;
@@ -40,7 +44,8 @@ public:
   void fetch_block_by_id(ton::BlockIdExt block_id, td::Promise<schema::BlockDataState> promise);
   void request_catch_up(td::Promise<td::Unit> promise);
 private:
-  void catch_up_with_primary(td::Promise<td::Unit> promise);
+  void start_catch_up_with_primary();
+  void catch_up_finished(td::Result<td::Unit> result, double elapsed_ms);
 };
 
 struct BlockIdExtHasher {


### PR DESCRIPTION
- Cap DB event reads and signed block fetches.
- Coalesce DB catch-up requests.
- Limit concurrent finalized/confirmed emulation.
- Finish empty masterchain emulation blocks correctly.
