### PR TITLE
Patch slow RocksDB open as secondary

### DIFF
--- a/ton-index-worker/CMakeLists.txt
+++ b/ton-index-worker/CMakeLists.txt
@@ -24,6 +24,20 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 add_subdirectory(external/ton EXCLUDE_FROM_ALL)
 add_subdirectory(external/libpqxx EXCLUDE_FROM_ALL)
 
+find_package(Git REQUIRED)
+set(TON_INDEXER_ROCKSDB_SECONDARY_OPEN_PATCH
+    ${CMAKE_CURRENT_SOURCE_DIR}/patches/fix-secondary-open.patch)
+add_custom_target(apply-rocksdb-secondary-open-patch
+  COMMAND ${CMAKE_COMMAND}
+    -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+    -DPATCH_FILE=${TON_INDEXER_ROCKSDB_SECONDARY_OPEN_PATCH}
+    -DPATCH_WORKING_DIRECTORY=${CMAKE_CURRENT_SOURCE_DIR}/external/ton/third-party/rocksdb
+    -P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/ApplyPatch.cmake
+  VERBATIM
+)
+add_dependencies(rocksdb apply-rocksdb-secondary-open-patch)
+
+
 # The TON subtree already provides an lz4 target.  Tell clickhouse-cpp to use
 # that configured library instead of adding its bundled target with the same
 # plain name.

--- a/ton-index-worker/cmake/ApplyPatch.cmake
+++ b/ton-index-worker/cmake/ApplyPatch.cmake
@@ -1,0 +1,59 @@
+if(NOT DEFINED PATCH_FILE)
+  message(FATAL_ERROR "PATCH_FILE is not set")
+endif()
+if(NOT DEFINED PATCH_WORKING_DIRECTORY)
+  message(FATAL_ERROR "PATCH_WORKING_DIRECTORY is not set")
+endif()
+if(NOT DEFINED GIT_EXECUTABLE)
+  message(FATAL_ERROR "GIT_EXECUTABLE is not set")
+endif()
+
+if(NOT EXISTS "${PATCH_FILE}")
+  message(FATAL_ERROR "Patch file does not exist: ${PATCH_FILE}")
+endif()
+if(NOT EXISTS "${PATCH_WORKING_DIRECTORY}")
+  message(FATAL_ERROR "Patch working directory does not exist: ${PATCH_WORKING_DIRECTORY}")
+endif()
+
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" -C "${PATCH_WORKING_DIRECTORY}" apply --check "${PATCH_FILE}"
+  RESULT_VARIABLE patch_can_apply
+  OUTPUT_QUIET
+  ERROR_VARIABLE patch_check_error
+)
+
+if(patch_can_apply EQUAL 0)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" -C "${PATCH_WORKING_DIRECTORY}" apply "${PATCH_FILE}"
+    RESULT_VARIABLE patch_apply_result
+    OUTPUT_VARIABLE patch_apply_output
+    ERROR_VARIABLE patch_apply_error
+  )
+  if(NOT patch_apply_result EQUAL 0)
+    message(FATAL_ERROR
+      "Failed to apply patch ${PATCH_FILE}\n"
+      "${patch_apply_output}\n"
+      "${patch_apply_error}"
+    )
+  endif()
+  message(STATUS "Applied patch: ${PATCH_FILE}")
+  return()
+endif()
+
+execute_process(
+  COMMAND "${GIT_EXECUTABLE}" -C "${PATCH_WORKING_DIRECTORY}" apply --reverse --check "${PATCH_FILE}"
+  RESULT_VARIABLE patch_already_applied
+  OUTPUT_QUIET
+  ERROR_VARIABLE patch_reverse_check_error
+)
+
+if(patch_already_applied EQUAL 0)
+  message(STATUS "Patch already applied: ${PATCH_FILE}")
+  return()
+endif()
+
+message(FATAL_ERROR
+  "Patch cannot be applied cleanly and is not already applied: ${PATCH_FILE}\n"
+  "git apply --check error:\n${patch_check_error}\n"
+  "git apply --reverse --check error:\n${patch_reverse_check_error}"
+)

--- a/ton-index-worker/patches/fix-secondary-open.patch
+++ b/ton-index-worker/patches/fix-secondary-open.patch
@@ -1,0 +1,113 @@
+diff --git a/db/version_edit_handler.cc b/db/version_edit_handler.cc
+index 42d83b84d..7d7e6911e 100644
+--- a/db/version_edit_handler.cc
++++ b/db/version_edit_handler.cc
+@@ -1047,6 +1047,47 @@ Status ManifestTailer::Initialize() {
+   return s;
+ }
+ 
++Status ManifestTailer::PrepareForCatchUpAfterRecover() {
++  assert(Mode::kRecovery == mode_);
++  assert(!initialized_);
++
++  ColumnFamilySet* cfd_set = version_set_->GetColumnFamilySet();
++  assert(cfd_set);
++  bool has_log_number = false;
++  uint64_t log_number = 0;
++  for (auto* cfd : *cfd_set) {
++    if (cfd->IsDropped()) {
++      continue;
++    }
++    assert(cfd->initialized());
++    if (!has_log_number || cfd->GetLogNumber() > log_number) {
++      log_number = cfd->GetLogNumber();
++      has_log_number = true;
++    }
++    assert(builders_.find(cfd->GetID()) == builders_.end());
++    builders_.emplace(cfd->GetID(), VersionBuilderUPtr(
++                                        new BaseReferencedVersionBuilder(
++                                            cfd, this,
++                                            track_found_and_missing_files_,
++                                            allow_incomplete_valid_version_)));
++  }
++  assert(has_log_number);
++
++  version_edit_params_.SetLogNumber(log_number);
++  version_edit_params_.SetPrevLogNumber(version_set_->prev_log_number());
++  auto next_file_number = version_set_->current_next_file_number();
++  assert(next_file_number > 0);
++  version_edit_params_.SetNextFile(next_file_number - 1);
++  version_edit_params_.SetMaxColumnFamily(cfd_set->GetMaxColumnFamily());
++  version_edit_params_.SetMinLogNumberToKeep(
++      version_set_->min_log_number_to_keep());
++  version_edit_params_.SetLastSequence(version_set_->LastSequence());
++
++  initialized_ = true;
++  mode_ = Mode::kCatchUp;
++  return Status::OK();
++}
++
+ Status ManifestTailer::ApplyVersionEdit(VersionEdit& edit,
+                                         ColumnFamilyData** cfd) {
+   Status s = VersionEditHandler::ApplyVersionEdit(edit, cfd);
+diff --git a/db/version_edit_handler.h b/db/version_edit_handler.h
+index 1d4b22e3c..65500ac73 100644
+--- a/db/version_edit_handler.h
++++ b/db/version_edit_handler.h
+@@ -373,6 +373,8 @@ class ManifestTailer : public VersionEditHandlerPointInTime {
+     ClearReadBuffer();
+   }
+ 
++  Status PrepareForCatchUpAfterRecover();
++
+   std::unordered_set<ColumnFamilyData*>& GetUpdatedColumnFamilies() {
+     return cfds_changed_;
+   }
+diff --git a/db/version_set.cc b/db/version_set.cc
+index cf89ec8ad..ab3d1e1c8 100644
+--- a/db/version_set.cc
++++ b/db/version_set.cc
+@@ -7860,19 +7860,36 @@ Status ReactiveVersionSet::Recover(
+   if (!s.ok()) {
+     return s;
+   }
++
+   log::Reader* reader = manifest_reader->get();
+   assert(reader);
+ 
+-  manifest_tailer_.reset(new ManifestTailer(
+-      column_families, const_cast<ReactiveVersionSet*>(this), io_tracer_,
+-      read_options_, EpochNumberRequirement::kMightMissing));
+-
+-  manifest_tailer_->Iterate(*reader, manifest_reader_status->get());
+-
+-  s = manifest_tailer_->status();
++  // TON indexer workaround for RocksDB secondary-open regression. After
++  // RocksDB PR #12928 (first released in v9.6.1), secondary point-in-time
++  // recovery can spend minutes replaying long MANIFEST histories through
++  // ManifestTailer because it repeatedly materializes intermediate Version
++  // states. Open the final manifest state with the regular VersionEditHandler
++  // instead, then bootstrap ManifestTailer in catch-up mode so
++  // TryCatchUpWithPrimary() continues tailing from this reader position.
++  VersionEditHandler handler(
++      /*read_only=*/true, column_families,
++      const_cast<ReactiveVersionSet*>(this),
++      /*track_found_and_missing_files=*/false,
++      /*no_error_if_files_missing=*/false, io_tracer_, read_options_,
++      /*allow_incomplete_valid_version=*/false,
++      EpochNumberRequirement::kMightMissing);
++  handler.Iterate(*reader, manifest_reader_status->get());
++  s = handler.status();
+   if (s.ok()) {
+     RecoverEpochNumbers();
++  } else {
++    return s;
+   }
++
++  manifest_tailer_.reset(new ManifestTailer(
++      column_families, const_cast<ReactiveVersionSet*>(this), io_tracer_,
++      read_options_, EpochNumberRequirement::kMightMissing));
++  s = manifest_tailer_->PrepareForCatchUpAfterRecover();
+   return s;
+ }
+ 


### PR DESCRIPTION
After RocksDB PR https://github.com/facebook/rocksdb/pull/12928 (first released in v9.6.1), secondary point-in-time recovery can spend minutes replaying long `MANIFEST` histories through `ManifestTailer` because it repeatedly materializes intermediate Version states. See also https://github.com/facebook/rocksdb/issues/14117.

This PR contains a patch to open the final manifest state with the regular `VersionEditHandler` instead, then bootstrap `ManifestTailer` in catch-up mode so `TryCatchUpWithPrimary()` continues tailing from this reader position.