### PR TITLE
Fix for build

### DIFF
--- a/ton-index-worker/ton-index-postgres/CMakeLists.txt
+++ b/ton-index-worker/ton-index-postgres/CMakeLists.txt
@@ -18,7 +18,6 @@ target_link_libraries(
     ton-kvrocks-state
     ton-observability
     pqxx
-    hiredis
     redis++_static
 )
 target_link_options(ton-index-postgres PUBLIC -rdynamic)

--- a/ton-index-worker/ton-kvrocks-state/CMakeLists.txt
+++ b/ton-index-worker/ton-kvrocks-state/CMakeLists.txt
@@ -15,6 +15,5 @@ target_compile_features(ton-kvrocks-state PRIVATE cxx_std_20)
 target_link_libraries(ton-kvrocks-state
     PUBLIC
         tondb-scanner
-        hiredis
         redis++_static
 )

--- a/ton-index-worker/ton-trace-emulator/CMakeLists.txt
+++ b/ton-index-worker/ton-trace-emulator/CMakeLists.txt
@@ -40,14 +40,8 @@ target_include_directories(ton-trace-emulator
     PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../external/redis-plus-plus/src
 )
 
-set(TRACE_EMULATOR_LINK_LIBS hiredis)
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    message("-- Skipping link hiredis for Darwin")
-    set(TRACE_EMULATOR_LINK_LIBS "")
-endif()
-
 target_compile_features(ton-trace-emulator PRIVATE cxx_std_20)
 target_compile_definitions(ton-trace-emulator PRIVATE -DMSGPACK_USE_DEFINE_MAP)
-target_link_libraries(ton-trace-emulator ton-trace-emulator-core redis++_static msgpack-cxx ${TRACE_EMULATOR_LINK_LIBS})
+target_link_libraries(ton-trace-emulator ton-trace-emulator-core redis++_static msgpack-cxx)
 target_link_options(ton-trace-emulator PUBLIC -rdynamic)
 install(TARGETS ton-trace-emulator RUNTIME DESTINATION bin)

--- a/ton-index-worker/ton-trace-emulator/src/OverlayListener.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/OverlayListener.cpp
@@ -1,9 +1,11 @@
 
 #include "OverlayListener.h"
+
+#include "Statistics.h"
+
+#include "TraceInterfaceDetector.h"
 #include <cstdint>
 #include <tdutils/td/utils/filesystem.h>
-#include "TraceInterfaceDetector.h"
-
 
 void OverlayListener::start_up() {
     auto pk = ton::PrivateKey{ton::privkeys::Ed25519::random()};

--- a/ton-index-worker/ton-trace-emulator/src/Serializer.hpp
+++ b/ton-index-worker/ton-trace-emulator/src/Serializer.hpp
@@ -1,9 +1,9 @@
 #pragma once
+#include "TraceEmulator.h"
+#include "convert-utils.h"
 #include "crypto/block/block-auto.h"
 #include "crypto/block/block-parse.h"
 #include "msgpack-utils.h"
-#include "TraceEmulator.h"
-
 
 enum AccountStatus {
   uninit = block::gen::AccountStatus::acc_state_uninit,

--- a/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
+++ b/ton-index-worker/ton-trace-emulator/src/TraceScheduler.cpp
@@ -1,18 +1,19 @@
 #include "TraceScheduler.h"
 #include "BlockEmulator.h"
+#include "Statistics.h"
 #include "TraceInserter.h"
-#include "td/utils/filesystem.h"
-#include "td/utils/Status.h"
 #include "common/delay.h"
-#include "validator/interfaces/block-handle.h"
+#include "td/utils/Status.h"
+#include "td/utils/filesystem.h"
+#include "td/utils/overloaded.h"
 #include "tl-utils/common-utils.hpp"
 #include "ton/ton-tl.hpp"
-#include "td/utils/overloaded.h"
-#include <unistd.h>
-#include <fcntl.h>
-#include <errno.h>
+#include "validator/interfaces/block-handle.h"
 #include <chrono>
 #include <cstdint>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
 
 namespace {
 constexpr const char* kHealthKey = "health:ton-trace-emulator";

--- a/ton-index-worker/ton-trace-task-emulator/CMakeLists.txt
+++ b/ton-index-worker/ton-trace-task-emulator/CMakeLists.txt
@@ -11,14 +11,8 @@ target_include_directories(ton-trace-task-emulator
     PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/../external/redis-plus-plus/src
 )
 
-set(TRACE_TASK_EMULATOR_LINK_LIBS hiredis)
-if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    message("-- Skipping link hiredis for Darwin")
-    set(TRACE_TASK_EMULATOR_LINK_LIBS "")
-endif()
-
 target_compile_features(ton-trace-task-emulator PRIVATE cxx_std_20)
-target_link_libraries(ton-trace-task-emulator ton-trace-emulator-core redis++_static msgpack-cxx ${TRACE_TASK_EMULATOR_LINK_LIBS})
+target_link_libraries(ton-trace-task-emulator ton-trace-emulator-core redis++_static msgpack-cxx)
 target_link_options(ton-trace-task-emulator PUBLIC -rdynamic)
 target_compile_definitions(ton-trace-task-emulator PRIVATE -DMSGPACK_USE_DEFINE_MAP)
 install(TARGETS ton-trace-task-emulator RUNTIME DESTINATION bin)

--- a/ton-index-worker/ton-trace-task-emulator/src/TraceTaskScheduler.cpp
+++ b/ton-index-worker/ton-trace-task-emulator/src/TraceTaskScheduler.cpp
@@ -1,8 +1,9 @@
 #include "TraceTaskScheduler.h"
-#include "TaskResultInserter.h"
-#include "td/utils/filesystem.h"
-#include "common/delay.h"
 
+#include "Statistics.h"
+#include "TaskResultInserter.h"
+#include "common/delay.h"
+#include "td/utils/filesystem.h"
 
 void TraceTaskScheduler::start_up() {
     alarm_timestamp() = td::Timestamp::in(0.1);


### PR DESCRIPTION
- Fixed missing headers.
- On macos there is an issue with hiredis lib, now it's statically linked to redis++_static, so no need to explicitly link it to targets.