### PR TITLE
refactor, timeout for acquire, kvrocks conn separated from pg

### DIFF
--- a/ton-index-go/index/crud/balances.go
+++ b/ton-index-go/index/crud/balances.go
@@ -1,7 +1,6 @@
 package crud
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"math"
@@ -146,8 +145,8 @@ func compare(t1 *ShortTransaction, t2 *ShortTransaction) int {
 	return 0
 }
 
-func CalculateBalanceChanges(traceId models.HashType, conn *pgxpool.Conn, store *KvrocksStore) (*BalanceChanges, map[models.HashType]*BalanceChanges, error) {
-	tx_map, err := fetchTrace(traceId, conn, store)
+func CalculateBalanceChanges(traceId models.HashType, conn *pgxpool.Conn, store *KvrocksStore, settings models.RequestSettings) (*BalanceChanges, map[models.HashType]*BalanceChanges, error) {
+	tx_map, err := fetchTrace(traceId, conn, store, settings)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -252,7 +251,7 @@ func CalculateBalanceChanges(traceId models.HashType, conn *pgxpool.Conn, store 
 		}
 	}
 
-	wallet_infos, err := checkJettonWallets(jetton_wallet_candidates, conn, store)
+	wallet_infos, err := checkJettonWallets(jetton_wallet_candidates, conn, store, settings)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -357,9 +356,11 @@ func (v *walletInfo) Equals(other *walletInfo) bool {
 	return v.address == other.address && v.owner == other.owner && v.jettonMaster == other.jettonMaster
 }
 
-func checkJettonWallets(jetton_wallet_candidates mapset.Set[models.AccountAddress], conn *pgxpool.Conn, store *KvrocksStore) (mapset.Set[walletInfo], error) {
+func checkJettonWallets(jetton_wallet_candidates mapset.Set[models.AccountAddress], conn *pgxpool.Conn, store *KvrocksStore, settings models.RequestSettings) (mapset.Set[walletInfo], error) {
 	if store != nil {
-		wallets, err := store.GetJettonWallets(context.Background(), jetton_wallet_candidates.ToSlice())
+		ctx, cancel := requestContext(settings)
+		defer cancel()
+		wallets, err := store.GetJettonWallets(ctx, jetton_wallet_candidates.ToSlice())
 		if err != nil {
 			return nil, err
 		}
@@ -378,7 +379,9 @@ func checkJettonWallets(jetton_wallet_candidates mapset.Set[models.AccountAddres
 		SELECT address, owner, jetton
 		FROM jetton_wallets
 		WHERE address = ANY($1) AND NOT destroyed`
-	rows, err := conn.Query(context.Background(), query, jetton_wallet_candidates.ToSlice())
+	ctx, cancel := requestContext(settings)
+	defer cancel()
+	rows, err := conn.Query(ctx, query, jetton_wallet_candidates.ToSlice())
 	if err != nil {
 		return nil, err
 	}
@@ -401,7 +404,7 @@ func checkJettonWallets(jetton_wallet_candidates mapset.Set[models.AccountAddres
 	return jetton_wallets, nil
 }
 
-func fetchTrace(trace_id models.HashType, conn *pgxpool.Conn, store *KvrocksStore) (map[models.HashType]*ShortTransaction, error) {
+func fetchTrace(trace_id models.HashType, conn *pgxpool.Conn, store *KvrocksStore, settings models.RequestSettings) (map[models.HashType]*ShortTransaction, error) {
 	var query string
 	if store != nil {
 		query = `
@@ -421,7 +424,9 @@ func fetchTrace(trace_id models.HashType, conn *pgxpool.Conn, store *KvrocksStor
 		LEFT JOIN message_contents MC ON M.body_hash = MC.hash
 		WHERE T.trace_id = $1`
 	}
-	rows, err := conn.Query(context.Background(), query, trace_id)
+	ctx, cancel := requestContext(settings)
+	defer cancel()
+	rows, err := conn.Query(ctx, query, trace_id)
 	if err != nil {
 		return nil, err
 	}
@@ -469,7 +474,9 @@ func fetchTrace(trace_id models.HashType, conn *pgxpool.Conn, store *KvrocksStor
 				hashes = append(hashes, *msg.BodyHash)
 			}
 		}
-		contents, err := store.GetMessageContents(context.Background(), hashes)
+		ctx, cancel := requestContext(settings)
+		defer cancel()
+		contents, err := store.GetMessageContents(ctx, hashes)
 		if err != nil {
 			return nil, err
 		}

--- a/ton-index-go/index/crud/crud.go
+++ b/ton-index-go/index/crud/crud.go
@@ -51,6 +51,43 @@ func limitOnlyQuery(limit *int32, settings models.RequestSettings) (string, erro
 	return limitQuery(models.LimitParams{Limit: limit}, settings)
 }
 
+func requestContext(settings models.RequestSettings) (context.Context, context.CancelFunc) {
+	if settings.Timeout <= 0 {
+		return context.WithCancel(context.Background())
+	}
+	return context.WithTimeout(context.Background(), settings.Timeout)
+}
+
+func acquireConnForRequest(pool *pgxpool.Pool, settings models.RequestSettings) (*pgxpool.Conn, func(), error) {
+	ctx, cancel := requestContext(settings)
+	conn, err := pool.Acquire(ctx)
+	cancel()
+	if err != nil {
+		return nil, nil, err
+	}
+	released := false
+	release := func() {
+		if released {
+			return
+		}
+		released = true
+		conn.Release()
+	}
+	return conn, release, nil
+}
+
+func (db *DbClient) acquireFedForRequest(settings models.RequestSettings) (*fedConns, func(), error) {
+	ctx, cancel := requestContext(settings)
+	fc, release, err := db.acquireFed(ctx)
+	cancel()
+	if err != nil {
+		return nil, nil, err
+	}
+	fc.ctx = context.Background()
+	fc.acquireTimeout = settings.Timeout
+	return fc, release, nil
+}
+
 func filterByArray[T any](clmn string, values []T) string {
 	filter_list := []string{}
 	filterStringIfaceType := reflect.TypeOf((*models.FilterStringInterface)(nil)).Elem()
@@ -189,7 +226,7 @@ func QueryMetadataImpl(addr_list []models.AccountAddress, conn *pgxpool.Conn, se
 	return metadata, nil
 }
 
-func (db *DbClient) queryKvrocksEnrichment(addrList []models.AccountAddress, settings models.RequestSettings, existingConn ...*pgxpool.Conn) (models.AddressBook, models.Metadata, error) {
+func (db *DbClient) queryKvrocksEnrichment(addrList []models.AccountAddress, settings models.RequestSettings) (models.AddressBook, models.Metadata, error) {
 	book := models.AddressBook{}
 	metadata := models.Metadata{}
 	var err error
@@ -242,11 +279,11 @@ func (db *DbClient) QueryAddressBookByAddresses(addrList []models.AccountAddress
 	if db.Kvrocks != nil {
 		return QueryAddressBookImplKvrocks(uniqueAddrList, db.Kvrocks, settings)
 	}
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 	return QueryAddressBookImpl(uniqueAddrList, conn, settings)
 }
 
@@ -403,11 +440,11 @@ func (db *DbClient) QueryMetadata(
 	if db.Kvrocks != nil {
 		return QueryMetadataImplKvrocks(addr_list, settings, db.Kvrocks)
 	}
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 	return QueryMetadataImpl(addr_list, conn, settings)
 }
 
@@ -447,11 +484,11 @@ func (db *DbClient) QueryAddressBook(
 		}
 		return new_addr_book, nil
 	}
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 	book, err := QueryAddressBookImpl(addr_list, conn, settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
@@ -482,7 +519,7 @@ func (db *DbClient) QueryBalanceChanges(
 		return models.BalanceChangesResult{}, models.IndexError{Code: 400, Message: "trace_id or action_id is required"}
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return models.BalanceChangesResult{}, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -503,7 +540,7 @@ func (db *DbClient) QueryBalanceChanges(
 		if trace_id == nil {
 			return nil, nil, false, models.IndexError{Code: 400, Message: "trace_id is required"}
 		}
-		tc, ac, e := CalculateBalanceChanges(models.HashType(*trace_id), conn, db.Kvrocks)
+		tc, ac, e := CalculateBalanceChanges(models.HashType(*trace_id), conn, db.Kvrocks, settings)
 		if e != nil {
 			if e.Error() == "trace not found" {
 				return nil, nil, false, nil // trace not on this side

--- a/ton-index-go/index/crud/crud_accounts.go
+++ b/ton-index-go/index/crud/crud_accounts.go
@@ -180,11 +180,11 @@ func (db *DbClient) QueryAccountStates(
 	}
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryAccountStateFullImpl(query, conn, settings)
 	if err != nil {
@@ -255,11 +255,11 @@ func (db *DbClient) QueryTopAccountBalances(req models.TopAccountsByBalanceReque
 	query := `select account, balance from latest_account_states order by balance desc` + limit_query
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryTopAccountBalancesImpl(query, conn, settings)
 	if err != nil {

--- a/ton-index-go/index/crud/crud_actions.go
+++ b/ton-index-go/index/crud/crud_actions.go
@@ -219,7 +219,7 @@ func buildActionsQuery(req models.ActionRequest, settings models.RequestSettings
 
 // queryActionsAccountsImpl attaches account lists to actions[idxs], querying conn
 // (the DB that owns those actions' partitions). Assigns in place.
-func queryActionsAccountsImpl(actions []models.Action, idxs []int, conn *pgxpool.Conn) error {
+func queryActionsAccountsImpl(actions []models.Action, idxs []int, conn *pgxpool.Conn, settings models.RequestSettings) error {
 	if len(idxs) == 0 {
 		return nil
 	}
@@ -242,7 +242,9 @@ func queryActionsAccountsImpl(actions []models.Action, idxs []int, conn *pgxpool
 		strings.Join(placeholders, ","),
 	)
 
-	rows, err := conn.Query(context.Background(), query, args...)
+	ctx, cancel := requestContext(settings)
+	defer cancel()
+	rows, err := conn.Query(ctx, query, args...)
 	if err != nil {
 		return models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -314,11 +316,11 @@ func (db *DbClient) QueryActions(
 	}
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	// check block
 	if seqno := req.McSeqno; seqno != nil {
@@ -353,7 +355,8 @@ func (db *DbClient) QueryActions(
 			addr_list = append(addr_list, k)
 		}
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}

--- a/ton-index-go/index/crud/crud_actions.go
+++ b/ton-index-go/index/crud/crud_actions.go
@@ -127,7 +127,7 @@ func buildActionsQuery(req models.ActionRequest, settings models.RequestSettings
 		filter_str := fmt.Sprintf("AA.account = '%s'::tonaddr", v.FilterString())
 		filter_list = append(filter_list, filter_str)
 
-		from_query = `action_accounts as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id`
+		from_query = `action_accounts as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id and A.trace_mc_seqno_end = AA.trace_mc_seqno_end`
 		if order_by_now {
 			clmn_query = `distinct on (AA.trace_end_utime, AA.trace_id, AA.action_end_utime, AA.action_id) ` + clmn_query_default
 		} else {

--- a/ton-index-go/index/crud/crud_actions_v2.go
+++ b/ton-index-go/index/crud/crud_actions_v2.go
@@ -416,7 +416,7 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 		filter_str := fmt.Sprintf("AA.account = '%s'::tonaddr", v.FilterString())
 		filter_list = append(filter_list, filter_str)
 
-		from_query = `action_accounts as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id`
+		from_query = `action_accounts as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id and A.trace_mc_seqno_end = AA.trace_mc_seqno_end`
 		if order_by_now {
 			clmn_query = `distinct on (AA.trace_end_utime, AA.trace_id, AA.action_end_utime, AA.action_id) ` + clmn_query_default
 		} else {
@@ -473,7 +473,7 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 			joined_accounts := strings.Contains(from_query, "action_accounts")
 			if join_accounts && joined_accounts {
 				// Limit action_accounts before join to keep account+trace_id requests fast.
-				from_query = fmt.Sprintf("(select * from action_accounts where %s) as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id", trace_filter)
+				from_query = fmt.Sprintf("(select * from action_accounts where %s) as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id and A.trace_mc_seqno_end = AA.trace_mc_seqno_end", trace_filter)
 			} else {
 				filter_str := filterByArray("A.trace_id", v)
 				if len(filter_str) > 0 {

--- a/ton-index-go/index/crud/crud_actions_v2.go
+++ b/ton-index-go/index/crud/crud_actions_v2.go
@@ -416,11 +416,18 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 		filter_str := fmt.Sprintf("AA.account = '%s'::tonaddr", v.FilterString())
 		filter_list = append(filter_list, filter_str)
 
-		from_query = `action_accounts as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id and A.trace_mc_seqno_end = AA.trace_mc_seqno_end`
+		from_query = `action_accounts as AA join lateral (
+			select *
+			from actions as A
+			where A.trace_id = AA.trace_id
+				and A.action_id = AA.action_id
+				and A.trace_mc_seqno_end = AA.trace_mc_seqno_end
+			limit 1
+		) as A on true`
 		if order_by_now {
-			clmn_query = `distinct on (AA.trace_end_utime, AA.trace_id, AA.action_end_utime, AA.action_id) ` + clmn_query_default
+			clmn_query = `distinct on (AA.account, AA.trace_end_utime, AA.trace_id, AA.action_end_utime, AA.action_id) ` + clmn_query_default
 		} else {
-			clmn_query = `distinct on (AA.trace_end_lt, AA.trace_id, AA.action_end_lt, AA.action_id) ` + clmn_query_default
+			clmn_query = `distinct on (AA.account, AA.trace_end_lt, AA.trace_id, AA.action_end_lt, AA.action_id) ` + clmn_query_default
 		}
 	}
 	if v := req.TransactionHash; v != nil {
@@ -489,11 +496,11 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 	}
 	if strings.Contains(from_query, "action_accounts") {
 		if order_by_now {
-			orderby_query = fmt.Sprintf(" order by AA.trace_end_utime %s, AA.trace_id %s, AA.action_end_utime %s, AA.action_id %s",
-				sort_order, sort_order, sort_order, sort_order)
+			orderby_query = fmt.Sprintf(" order by AA.account %s, AA.trace_end_utime %s, AA.trace_id %s, AA.action_end_utime %s, AA.action_id %s",
+				sort_order, sort_order, sort_order, sort_order, sort_order)
 		} else {
-			orderby_query = fmt.Sprintf(" order by AA.trace_end_lt %s, AA.trace_id %s, AA.action_end_lt %s, AA.action_id %s",
-				sort_order, sort_order, sort_order, sort_order)
+			orderby_query = fmt.Sprintf(" order by AA.account %s, AA.trace_end_lt %s, AA.trace_id %s, AA.action_end_lt %s, AA.action_id %s",
+				sort_order, sort_order, sort_order, sort_order, sort_order)
 		}
 	} else {
 		if order_by_now {
@@ -578,6 +585,7 @@ func buildActionsCountQueryV2(p actionsQueryParts, floor, ceil *uint64) string {
 func queryRawActionsImplV2(query string, args []any, conn *pgxpool.Conn, settings models.RequestSettings) ([]models.RawAction, error) {
 	ctx, cancel_ctx := context.WithTimeout(context.Background(), settings.Timeout)
 	defer cancel_ctx()
+
 	rows, err := conn.Query(ctx, query, args...)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
@@ -588,7 +596,6 @@ func queryRawActionsImplV2(query string, args []any, conn *pgxpool.Conn, setting
 	// default:
 	// }
 	defer rows.Close()
-
 	res := []models.RawAction{}
 	for rows.Next() {
 		if loc, err := parse.ScanRawAction(rows); err == nil {

--- a/ton-index-go/index/crud/crud_actions_v2.go
+++ b/ton-index-go/index/crud/crud_actions_v2.go
@@ -44,7 +44,7 @@ func (db *DbClient) QueryActionsV2(
 
 	parts := actionsQueryPartsV2(req, sortOrder)
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -102,12 +102,12 @@ func (db *DbClient) QueryActionsV2(
 		actions = append(actions, *action)
 	}
 	if req.IncludeAccounts != nil && *req.IncludeAccounts {
-		if err := enrichActionsAccounts(fc, actions); err != nil {
+		if err := enrichActionsAccounts(fc, actions, settings); err != nil {
 			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 		}
 	}
 	if req.IncludeTransactions != nil && *req.IncludeTransactions {
-		actions, err = queryActionsTransactionsImpl(fc, actions, settings, db.Kvrocks)
+		actions, err = queryActionsTransactionsImpl(fc, release, actions, settings, db.Kvrocks)
 		if err != nil {
 			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 		}
@@ -117,16 +117,17 @@ func (db *DbClient) QueryActionsV2(
 		for k := range addr_map {
 			addr_list = append(addr_list, k)
 		}
-		coldConn, cerr := fc.cold()
-		if cerr != nil {
-			return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
-		}
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, coldConn)
+			release()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
 		} else {
+			coldConn, cerr := fc.cold()
+			if cerr != nil {
+				return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
+			}
 			if !settings.NoAddressBook {
 				book, err = QueryAddressBookImpl(addr_list, coldConn, settings)
 				if err != nil {
@@ -146,7 +147,7 @@ func (db *DbClient) QueryActionsV2(
 
 // enrichActionsAccounts attaches each action's account list, routed to the DB that
 // owns the action's partition (trace_mc_seqno_end), batched per side.
-func enrichActionsAccounts(fc *fedConns, actions []models.Action) error {
+func enrichActionsAccounts(fc *fedConns, actions []models.Action, settings models.RequestSettings) error {
 	if len(actions) == 0 {
 		return nil
 	}
@@ -163,7 +164,7 @@ func enrichActionsAccounts(fc *fedConns, actions []models.Action) error {
 		if err != nil {
 			return err
 		}
-		if err := queryActionsAccountsImpl(actions, hotIdx, conn); err != nil {
+		if err := queryActionsAccountsImpl(actions, hotIdx, conn, settings); err != nil {
 			return err
 		}
 	}
@@ -172,7 +173,7 @@ func enrichActionsAccounts(fc *fedConns, actions []models.Action) error {
 		if err != nil {
 			return err
 		}
-		if err := queryActionsAccountsImpl(actions, coldIdx, conn); err != nil {
+		if err := queryActionsAccountsImpl(actions, coldIdx, conn, settings); err != nil {
 			return err
 		}
 	}
@@ -602,7 +603,7 @@ func queryRawActionsImplV2(query string, args []any, conn *pgxpool.Conn, setting
 	return res, nil
 }
 
-func queryActionsTransactionsImpl(fc *fedConns, actions []models.Action, settings models.RequestSettings, store *KvrocksStore) ([]models.Action, error) {
+func queryActionsTransactionsImpl(fc *fedConns, release func(), actions []models.Action, settings models.RequestSettings, store *KvrocksStore) ([]models.Action, error) {
 	if len(actions) == 0 {
 		return actions, nil
 	}
@@ -641,6 +642,12 @@ func queryActionsTransactionsImpl(fc *fedConns, actions []models.Action, setting
 		func(t *models.Transaction) models.HashType { return t.Hash })
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
+	}
+	if store != nil {
+		release()
+		if err := finalizeTransactionSliceFromKvrocks(txs, nil, store, settings); err != nil {
+			return nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
 	}
 
 	// Create a map of transactions by hash

--- a/ton-index-go/index/crud/crud_blocks.go
+++ b/ton-index-go/index/crud/crud_blocks.go
@@ -121,31 +121,24 @@ func queryBlocksImpl(query string, conn *pgxpool.Conn, settings models.RequestSe
 }
 
 func queryBlockExists(seqno int32, conn *pgxpool.Conn, settings models.RequestSettings) (bool, error) {
-	query := fmt.Sprintf(`select seqno from blocks where workchain = -1 and shard = -9223372036854775808 and seqno = %d`, seqno)
 	ctx, cancel_ctx := context.WithTimeout(context.Background(), settings.Timeout)
 	defer cancel_ctx()
-	rows, err := conn.Query(ctx, query)
-	if err != nil {
+	query := `select exists (
+		select 1 from blocks
+		where workchain = -1
+		  and shard = -9223372036854775808
+		  and seqno = $1
+	)`
+	var exists bool
+	if err := conn.QueryRow(ctx, query, seqno).Scan(&exists); err != nil {
 		return false, models.IndexError{Code: 500, Message: err.Error()}
 	}
-
-	seqnos := []int32{}
-	for rows.Next() {
-		var s int32
-		if err := rows.Scan(&s); err != nil {
-			return false, err
-		}
-		seqnos = append(seqnos, s)
-	}
-	if rows.Err() != nil {
-		return false, models.IndexError{Code: 500, Message: rows.Err().Error()}
-	}
-	return len(seqnos) > 0, nil
+	return exists, nil
 }
 
 // Exported methods
 func (db *DbClient) QueryMasterchainInfo(settings models.RequestSettings) (*models.MasterchainInfo, error) {
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -205,7 +198,7 @@ func (db *DbClient) QueryBlocks(
 		}
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -254,7 +247,7 @@ func (db *DbClient) QueryShards(
 		order by S.mc_seqno, S.workchain, S.shard, S.seqno`, req.Seqno)
 
 	// a masterchain round and its shards live wholly in one partition
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}

--- a/ton-index-go/index/crud/crud_dns.go
+++ b/ton-index-go/index/crud/crud_dns.go
@@ -36,11 +36,11 @@ func (db *DbClient) QueryDNSRecords(req models.DNSRecordsRequest, settings model
 		return records, book, nil
 	}
 
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	limit_query, err := limitQuery(lim_req, settings)
 	if err != nil {

--- a/ton-index-go/index/crud/crud_jettons.go
+++ b/ton-index-go/index/crud/crud_jettons.go
@@ -509,11 +509,11 @@ func (db *DbClient) QueryJettonMasters(
 	}
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryJettonMastersImpl(query, conn, settings)
 	if err != nil {
@@ -531,7 +531,8 @@ func (db *DbClient) QueryJettonMasters(
 	}
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
@@ -586,11 +587,11 @@ func (db *DbClient) QueryJettonWallets(
 	}
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryJettonWalletsImpl(query, conn, settings)
 	if err != nil {
@@ -608,7 +609,8 @@ func (db *DbClient) QueryJettonWallets(
 	}
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
@@ -661,7 +663,7 @@ func (db *DbClient) QueryJettonTransfers(
 		orderKey = "utime"
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -700,16 +702,17 @@ func (db *DbClient) QueryJettonTransfers(
 		}
 	}
 	if len(addr_list) > 0 {
-		coldConn, cerr := fc.cold()
-		if cerr != nil {
-			return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
-		}
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, coldConn)
+			release()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
 		} else {
+			coldConn, cerr := fc.cold()
+			if cerr != nil {
+				return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
+			}
 			if !settings.NoAddressBook {
 				book, err = QueryAddressBookImpl(addr_list, coldConn, settings)
 				if err != nil {
@@ -758,7 +761,7 @@ func (db *DbClient) QueryJettonBurns(
 		orderKey = "utime"
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -796,16 +799,17 @@ func (db *DbClient) QueryJettonBurns(
 		}
 	}
 	if len(addr_list) > 0 {
-		coldConn, cerr := fc.cold()
-		if cerr != nil {
-			return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
-		}
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, coldConn)
+			release()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
 		} else {
+			coldConn, cerr := fc.cold()
+			if cerr != nil {
+				return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
+			}
 			if !settings.NoAddressBook {
 				book, err = QueryAddressBookImpl(addr_list, coldConn, settings)
 				if err != nil {

--- a/ton-index-go/index/crud/crud_messages.go
+++ b/ton-index-go/index/crud/crud_messages.go
@@ -156,13 +156,24 @@ func buildMessagesCountQuery(p msgQueryParts, floor, ceil, ltSeam *uint64) strin
 	return `select count(*) from (` + messagesPageInner(p, floor, ceil, ltSeam, ``) + `) as sub`
 }
 
-func attachMessageContentsFromKvrocks(msgs []models.Message, store *KvrocksStore, settings models.RequestSettings) error {
+func messagePtrs(msgs []models.Message) []*models.Message {
+	ptrs := make([]*models.Message, 0, len(msgs))
+	for i := range msgs {
+		ptrs = append(ptrs, &msgs[i])
+	}
+	return ptrs
+}
+
+func attachMessageContentsFromKvrocks(msgs []*models.Message, store *KvrocksStore, settings models.RequestSettings) error {
 	if store == nil || len(msgs) == 0 {
 		return nil
 	}
 
 	hashes := make([]models.HashType, 0, len(msgs)*2)
 	for _, msg := range msgs {
+		if msg == nil {
+			continue
+		}
 		if msg.BodyHash != nil {
 			hashes = append(hashes, *msg.BodyHash)
 		}
@@ -182,23 +193,48 @@ func attachMessageContentsFromKvrocks(msgs []models.Message, store *KvrocksStore
 	}
 
 	for idx := range msgs {
-		if msgs[idx].BodyHash != nil {
-			if content, ok := contents[*msgs[idx].BodyHash]; ok {
+		msg := msgs[idx]
+		if msg == nil {
+			continue
+		}
+		if msg.BodyHash != nil {
+			if content, ok := contents[*msg.BodyHash]; ok {
 				loc := *content
-				msgs[idx].MessageContent = &loc
+				msg.MessageContent = &loc
 			}
 		}
-		if msgs[idx].InitStateHash != nil {
-			if content, ok := contents[*msgs[idx].InitStateHash]; ok {
+		if msg.InitStateHash != nil {
+			if content, ok := contents[*msg.InitStateHash]; ok {
 				loc := *content
-				msgs[idx].InitState = &loc
+				msg.InitState = &loc
 			}
 		}
 	}
 	return nil
 }
 
-func queryMessagesImpl(query string, conn *pgxpool.Conn, settings models.RequestSettings, store *KvrocksStore, args ...any) ([]models.Message, error) {
+func finalizeMessagePtrs(msgs []*models.Message, store *KvrocksStore, settings models.RequestSettings) error {
+	if err := attachMessageContentsFromKvrocks(msgs, store, settings); err != nil {
+		return models.IndexError{Code: 500, Message: err.Error()}
+	}
+
+	if err := detect.MarkMessagesByPtr(msgs); err != nil {
+		hashes := make([]string, 0, len(msgs))
+		for _, msg := range msgs {
+			if msg != nil {
+				hashes = append(hashes, msg.MsgHash.String())
+			}
+		}
+		log.Printf("Error marking messages with hashes %v: %v", hashes, err)
+	}
+	return nil
+}
+
+func finalizeMessages(msgs []models.Message, store *KvrocksStore, settings models.RequestSettings) error {
+	return finalizeMessagePtrs(messagePtrs(msgs), store, settings)
+}
+
+func queryMessagesImpl(query string, conn *pgxpool.Conn, settings models.RequestSettings, args ...any) ([]models.Message, error) {
 	msgs := []models.Message{}
 	{
 		ctx, cancel_ctx := context.WithTimeout(context.Background(), settings.Timeout)
@@ -224,19 +260,6 @@ func queryMessagesImpl(query string, conn *pgxpool.Conn, settings models.Request
 		if rows.Err() != nil {
 			return nil, models.IndexError{Code: 500, Message: rows.Err().Error()}
 		}
-	}
-
-	if err := attachMessageContentsFromKvrocks(msgs, store, settings); err != nil {
-		return nil, models.IndexError{Code: 500, Message: err.Error()}
-	}
-
-	// decode opcodes and bodies
-	if err := detect.MarkMessages(msgs); err != nil {
-		hashes := make([]string, len(msgs))
-		for i, msg := range msgs {
-			hashes[i] = msg.MsgHash.String()
-		}
-		log.Printf("Error marking messages with hashes %v: %v", hashes, err)
 	}
 
 	return msgs, nil
@@ -273,7 +296,7 @@ func (db *DbClient) QueryMessages(
 		orderKey = "utime"
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -283,7 +306,7 @@ func (db *DbClient) QueryMessages(
 		if settings.DebugRequest {
 			log.Println("Debug query:", query)
 		}
-		return queryMessagesImpl(query, conn, settings, db.Kvrocks, parts.args...)
+		return queryMessagesImpl(query, conn, settings, parts.args...)
 	}
 
 	// externals have a null sort axis (created_lt/created_at); band them by tx_lt at
@@ -312,6 +335,12 @@ func (db *DbClient) QueryMessages(
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
+	if db.Kvrocks != nil {
+		release()
+	}
+	if err := finalizeMessages(msgs, db.Kvrocks, settings); err != nil {
+		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+	}
 
 	book := models.AddressBook{}
 	metadata := models.Metadata{}
@@ -325,16 +354,17 @@ func (db *DbClient) QueryMessages(
 		}
 	}
 	if len(addr_list) > 0 {
-		coldConn, cerr := fc.cold()
-		if cerr != nil {
-			return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
-		}
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, coldConn)
+			release()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
 		} else {
+			coldConn, cerr := fc.cold()
+			if cerr != nil {
+				return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
+			}
 			if !settings.NoAddressBook {
 				book, err = QueryAddressBookImpl(addr_list, coldConn, settings)
 				if err != nil {

--- a/ton-index-go/index/crud/crud_multisig.go
+++ b/ton-index-go/index/crud/crud_multisig.go
@@ -198,11 +198,11 @@ func (db *DbClient) QueryMultisigs(
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
 
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	multisigs, err := queryMultisigImpl(query, conn, settings)
 	if err != nil {
@@ -308,11 +308,11 @@ func (db *DbClient) QueryMultisigOrders(
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
 
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	orders, err := queryMultisigOrderImpl(query, conn, settings)
 	if err != nil {

--- a/ton-index-go/index/crud/crud_nft.go
+++ b/ton-index-go/index/crud/crud_nft.go
@@ -369,11 +369,11 @@ func (db *DbClient) QueryNFTCollections(
 	}
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryNFTCollectionsImpl(query, conn, settings)
 	if err != nil {
@@ -391,7 +391,8 @@ func (db *DbClient) QueryNFTCollections(
 	}
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
@@ -459,11 +460,11 @@ func (db *DbClient) QueryNFTItems(
 	}
 
 	// read data
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryNFTItemsWithCollectionsImpl(query, conn, settings, args...)
 	if err != nil {
@@ -520,7 +521,7 @@ func (db *DbClient) QueryNFTTransfers(
 		}
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -570,6 +571,7 @@ func (db *DbClient) QueryNFTTransfers(
 	}
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
+			release()
 			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}

--- a/ton-index-go/index/crud/crud_pending.go
+++ b/ton-index-go/index/crud/crud_pending.go
@@ -20,11 +20,11 @@ func (db *DbClient) QueryPendingActions(settings models.RequestSettings, emulate
 	if db.HotPool != nil {
 		pool = db.HotPool
 	}
-	conn, err := pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	raw_actions, err := queryPendingActionsImpl(emulatedContext, conn, settings, request)
 	if err != nil {
@@ -43,32 +43,6 @@ func (db *DbClient) QueryPendingActions(settings models.RequestSettings, emulate
 			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 		}
 		actions = append(actions, *action)
-	}
-
-	if len(addr_map) > 0 {
-		var addr_list []models.AccountAddress
-		for k := range addr_map {
-			addr_list = append(addr_list, k)
-		}
-		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
-			if err != nil {
-				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
-			}
-		} else {
-			if !settings.NoAddressBook {
-				book, err = QueryAddressBookImpl(addr_list, conn, settings)
-				if err != nil {
-					return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
-				}
-			}
-			if !settings.NoMetadata {
-				metadata, err = QueryMetadataImpl(addr_list, conn, settings)
-				if err != nil {
-					return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
-				}
-			}
-		}
 	}
 
 	if request.IncludeTransactions != nil && *request.IncludeTransactions {
@@ -92,6 +66,33 @@ func (db *DbClient) QueryPendingActions(settings models.RequestSettings, emulate
 		}
 	}
 
+	if len(addr_map) > 0 {
+		var addr_list []models.AccountAddress
+		for k := range addr_map {
+			addr_list = append(addr_list, k)
+		}
+		if db.Kvrocks != nil {
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
+			if err != nil {
+				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+			}
+		} else {
+			if !settings.NoAddressBook {
+				book, err = QueryAddressBookImpl(addr_list, conn, settings)
+				if err != nil {
+					return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+				}
+			}
+			if !settings.NoMetadata {
+				metadata, err = QueryMetadataImpl(addr_list, conn, settings)
+				if err != nil {
+					return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+				}
+			}
+		}
+	}
+
 	return actions, book, metadata, nil
 }
 
@@ -101,11 +102,11 @@ func (db *DbClient) QueryPendingTraces(settings models.RequestSettings, emulated
 	if db.HotPool != nil {
 		pool = db.HotPool
 	}
-	conn, err := pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(pool, settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, addr_list, err := queryPendingTracesImpl(emulatedContext, conn, settings, request)
 	if err != nil {
@@ -118,7 +119,8 @@ func (db *DbClient) QueryPendingTraces(settings models.RequestSettings, emulated
 
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
@@ -155,11 +157,11 @@ func (db *DbClient) QueryPendingTransactions(
 	if db.HotPool != nil {
 		pool = db.HotPool
 	}
-	conn, err := pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(pool, settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	txs, err := QueryPendingTransactionsImpl(emulatedContext, conn, settings, true)
 	if err != nil {
@@ -183,6 +185,7 @@ func (db *DbClient) QueryPendingTransactions(
 	book := models.AddressBook{}
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
+			releaseConn()
 			book, err = QueryAddressBookImplKvrocks(addr_list, db.Kvrocks, settings)
 		} else {
 			book, err = QueryAddressBookImpl(addr_list, conn, settings)
@@ -218,6 +221,7 @@ func queryCompletedEmulatedTraces(emulatedContext *EmulatedTracesContext,
 		if err != nil {
 			return nil, models.IndexError{Code: 500, Message: err.Error()}
 		}
+		defer rows.Close()
 		completed_trace_ids_in_db := make([]string, 0)
 		for rows.Next() {
 			var external_hash string
@@ -225,6 +229,9 @@ func queryCompletedEmulatedTraces(emulatedContext *EmulatedTracesContext,
 				return nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
 			completed_trace_ids_in_db = append(completed_trace_ids_in_db, external_hash_map[external_hash])
+		}
+		if err := rows.Err(); err != nil {
+			return nil, models.IndexError{Code: 500, Message: err.Error()}
 		}
 		return completed_trace_ids_in_db, nil
 	}

--- a/ton-index-go/index/crud/crud_sales.go
+++ b/ton-index-go/index/crud/crud_sales.go
@@ -376,11 +376,16 @@ func (db *DbClient) QueryNFTSales(
 		return nil, nil, nil, models.IndexError{Code: 422, Message: "maximum 1000 addresses allowed"}
 	}
 
-	conn, err := db.Pool.Acquire(context.Background())
-	if err != nil {
-		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+	var conn *pgxpool.Conn
+	releaseConn := func() {}
+	var err error
+	if db.Kvrocks == nil {
+		conn, releaseConn, err = acquireConnForRequest(db.Pool, settings)
+		if err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	res, err := queryNFTSalesImpl(sales_req.Address, conn, settings, db.Kvrocks)
 	if err != nil {
@@ -455,7 +460,8 @@ func (db *DbClient) QueryNFTSales(
 
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, conn)
+			releaseConn()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}

--- a/ton-index-go/index/crud/crud_traces.go
+++ b/ton-index-go/index/crud/crud_traces.go
@@ -441,6 +441,11 @@ func queryTracesImpl(query string, includeActions bool, supportedActionTypes []s
 			if err != nil {
 				return nil, nil, models.IndexError{Code: 500, Message: fmt.Sprintf("failed query transactions: %s", err.Error())}
 			}
+			if store != nil {
+				if err := finalizeTransactionSliceFromKvrocks(txs, nil, store, settings); err != nil {
+					return nil, nil, models.IndexError{Code: 500, Message: fmt.Sprintf("failed enrich transactions: %s", err.Error())}
+				}
+			}
 			for idx := range txs {
 				tx := &txs[idx]
 
@@ -844,8 +849,6 @@ func (db *DbClient) QueryTraces(
 	req models.TracesRequest,
 	settings models.RequestSettings,
 ) ([]models.Trace, models.AddressBook, models.Metadata, error) {
-	ctx := context.Background()
-
 	lim_req := req.GetLimitParams()
 
 	sortOrder := "desc"
@@ -865,7 +868,7 @@ func (db *DbClient) QueryTraces(
 		}
 	}
 
-	fc, release, err := db.acquireFed(ctx)
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -933,20 +936,30 @@ func (db *DbClient) QueryTraces(
 		}
 		return nil
 	}
-	hot, err := fc.hot()
-	if err != nil {
-		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
-	}
-	if err := collect(hot, hotIdx); err != nil {
-		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+	if len(hotIdx) > 0 {
+		hot, err := fc.hot()
+		if err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
+		if err := collect(hot, hotIdx); err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
 	}
 
-	cold, err := fc.cold()
-	if err != nil {
-		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+	if len(coldIdx) > 0 {
+		cold, err := fc.cold()
+		if err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
+		if err := collect(cold, coldIdx); err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
 	}
-	if err := collect(cold, coldIdx); err != nil {
-		return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+	if db.Kvrocks != nil {
+		release()
+		if err := finalizeTraceTransactionsFromKvrocks(traces, db.Kvrocks, settings); err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
 	}
 
 	addr_list := make([]models.AccountAddress, 0, len(addr_set))
@@ -959,11 +972,16 @@ func (db *DbClient) QueryTraces(
 	metadata := models.Metadata{}
 	if len(addr_list) > 0 {
 		if db.Kvrocks != nil {
-			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings, cold)
+			release()
+			book, metadata, err = db.queryKvrocksEnrichment(addr_list, settings)
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
 		} else {
+			cold, err := fc.cold()
+			if err != nil {
+				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+			}
 			if !settings.NoAddressBook {
 				book, err = QueryAddressBookImpl(addr_list, cold, settings)
 				if err != nil {

--- a/ton-index-go/index/crud/crud_transactions.go
+++ b/ton-index-go/index/crud/crud_transactions.go
@@ -211,48 +211,27 @@ func queryTransactionsImpl(query string, conn *pgxpool.Conn, settings models.Req
 	if len(txs) == 0 {
 		return txs, nil
 	}
-	if len(acst_list) > 0 {
-		if store != nil {
-			hashes := make([]models.HashType, 0, len(txs)*2)
-			for _, tx := range txs {
-				hashes = append(hashes, tx.AccountStateHashBefore, tx.AccountStateHashAfter)
-			}
-			ctx, cancel_ctx := context.WithTimeout(context.Background(), settings.Timeout)
-			defer cancel_ctx()
-			acsts_map, err := store.GetAccountStates(ctx, hashes)
-			if err != nil {
-				return nil, models.IndexError{Code: 500, Message: err.Error()}
-			}
-			for idx := range txs {
-				if v, ok := acsts_map[txs[idx].AccountStateHashBefore]; ok {
-					txs[idx].AccountStateBefore = v
-				}
-				if v, ok := acsts_map[txs[idx].AccountStateHashAfter]; ok {
-					txs[idx].AccountStateAfter = v
-				}
-			}
-		} else {
-			acst_list_str := strings.Join(acst_list, ",")
-			query = fmt.Sprintf(`select S.hash, S.account, S.balance, 
+	if len(acst_list) > 0 && store == nil {
+		acst_list_str := strings.Join(acst_list, ",")
+		query = fmt.Sprintf(`select S.hash, S.account, S.balance,
 		S.balance_extra_currencies, S.account_status, S.frozen_hash, 
 		S.data_hash, S.code_hash from account_states S where hash in (%s)`, acst_list_str)
 
-			acsts, err := queryAccountStatesImpl(query, conn, settings)
-			if err != nil {
-				return nil, models.IndexError{Code: 500, Message: err.Error()}
+		acsts, err := queryAccountStatesImpl(query, conn, settings)
+		if err != nil {
+			return nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
+		acsts_map := make(map[models.HashType]*models.AccountState)
+		for _, a := range acsts {
+			acst := a
+			acsts_map[acst.Hash] = &acst
+		}
+		for idx := range txs {
+			if v, ok := acsts_map[txs[idx].AccountStateHashBefore]; ok {
+				txs[idx].AccountStateBefore = v
 			}
-			acsts_map := make(map[models.HashType]*models.AccountState)
-			for _, a := range acsts {
-				acst := a
-				acsts_map[acst.Hash] = &acst
-			}
-			for idx := range txs {
-				if v, ok := acsts_map[txs[idx].AccountStateHashBefore]; ok {
-					txs[idx].AccountStateBefore = v
-				}
-				if v, ok := acsts_map[txs[idx].AccountStateHashAfter]; ok {
-					txs[idx].AccountStateAfter = v
-				}
+			if v, ok := acsts_map[txs[idx].AccountStateHashAfter]; ok {
+				txs[idx].AccountStateAfter = v
 			}
 		}
 	}
@@ -275,9 +254,14 @@ func queryTransactionsImpl(query string, conn *pgxpool.Conn, settings models.Req
 			where M.tx_hash in (%s)`, hash_list_str)
 		}
 
-		msgs, err := queryMessagesImpl(query, conn, settings, store)
+		msgs, err := queryMessagesImpl(query, conn, settings)
 		if err != nil {
 			return nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
+		if store == nil {
+			if err := finalizeMessages(msgs, nil, settings); err != nil {
+				return nil, models.IndexError{Code: 500, Message: err.Error()}
+			}
 		}
 
 		for _, msg := range msgs {
@@ -303,6 +287,98 @@ func queryTransactionsImpl(query string, conn *pgxpool.Conn, settings models.Req
 	}
 
 	return txs, nil
+}
+
+func transactionPtrs(txs []models.Transaction, idxs []int) []*models.Transaction {
+	if len(txs) == 0 {
+		return nil
+	}
+	if idxs == nil {
+		ptrs := make([]*models.Transaction, 0, len(txs))
+		for i := range txs {
+			ptrs = append(ptrs, &txs[i])
+		}
+		return ptrs
+	}
+
+	ptrs := make([]*models.Transaction, 0, len(idxs))
+	for _, i := range idxs {
+		if i >= 0 && i < len(txs) {
+			ptrs = append(ptrs, &txs[i])
+		}
+	}
+	return ptrs
+}
+
+func transactionMessagePtrs(txs []*models.Transaction) []*models.Message {
+	msgs := make([]*models.Message, 0)
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		if tx.InMsg != nil {
+			msgs = append(msgs, tx.InMsg)
+		}
+		msgs = append(msgs, tx.OutMsgs...)
+	}
+	return msgs
+}
+
+func finalizeTransactionSliceFromKvrocks(txs []models.Transaction, idxs []int, store *KvrocksStore, settings models.RequestSettings) error {
+	return finalizeTransactionPtrsFromKvrocks(transactionPtrs(txs, idxs), store, settings)
+}
+
+func finalizeTransactionPtrsFromKvrocks(txs []*models.Transaction, store *KvrocksStore, settings models.RequestSettings) error {
+	if store == nil || len(txs) == 0 {
+		return nil
+	}
+
+	hashes := make([]models.HashType, 0, len(txs)*2)
+	for _, tx := range txs {
+		if tx == nil {
+			continue
+		}
+		hashes = append(hashes, tx.AccountStateHashBefore, tx.AccountStateHashAfter)
+	}
+	if len(hashes) > 0 {
+		ctx, cancel_ctx := context.WithTimeout(context.Background(), settings.Timeout)
+		defer cancel_ctx()
+		acsts_map, err := store.GetAccountStates(ctx, hashes)
+		if err != nil {
+			return models.IndexError{Code: 500, Message: err.Error()}
+		}
+		for _, tx := range txs {
+			if tx == nil {
+				continue
+			}
+			if v, ok := acsts_map[tx.AccountStateHashBefore]; ok {
+				tx.AccountStateBefore = v
+			}
+			if v, ok := acsts_map[tx.AccountStateHashAfter]; ok {
+				tx.AccountStateAfter = v
+			}
+		}
+	}
+
+	return finalizeMessagePtrs(transactionMessagePtrs(txs), store, settings)
+}
+
+func finalizeTraceTransactionsFromKvrocks(traces []models.Trace, store *KvrocksStore, settings models.RequestSettings) error {
+	if store == nil || len(traces) == 0 {
+		return nil
+	}
+	seen := make(map[models.HashType]bool)
+	txs := make([]*models.Transaction, 0)
+	for i := range traces {
+		for _, tx := range traces[i].Transactions {
+			if tx == nil || seen[tx.Hash] {
+				continue
+			}
+			seen[tx.Hash] = true
+			txs = append(txs, tx)
+		}
+	}
+	return finalizeTransactionPtrsFromKvrocks(txs, store, settings)
 }
 
 func queryAdjacentTransactionsImpl(req models.AdjacentTransactionRequest, conn *pgxpool.Conn, settings models.RequestSettings) ([]models.HashType, error) {
@@ -402,26 +478,7 @@ func enrichTransactionsImpl(txs []models.Transaction, idxs []int, conn *pgxpool.
 	}
 
 	// account states
-	if store != nil {
-		hashes := make([]models.HashType, 0, len(idxs)*2)
-		for _, i := range idxs {
-			hashes = append(hashes, txs[i].AccountStateHashBefore, txs[i].AccountStateHashAfter)
-		}
-		ctx, cancel_ctx := context.WithTimeout(context.Background(), settings.Timeout)
-		defer cancel_ctx()
-		acsts_map, err := store.GetAccountStates(ctx, hashes)
-		if err != nil {
-			return models.IndexError{Code: 500, Message: err.Error()}
-		}
-		for _, i := range idxs {
-			if v, ok := acsts_map[txs[i].AccountStateHashBefore]; ok {
-				txs[i].AccountStateBefore = v
-			}
-			if v, ok := acsts_map[txs[i].AccountStateHashAfter]; ok {
-				txs[i].AccountStateAfter = v
-			}
-		}
-	} else {
+	if store == nil {
 		acst_list_str := strings.Join(acst_list, ",")
 		query := fmt.Sprintf(`select S.hash, S.account, S.balance,
 	S.balance_extra_currencies, S.account_status, S.frozen_hash,
@@ -464,9 +521,14 @@ func enrichTransactionsImpl(txs []models.Transaction, idxs []int, conn *pgxpool.
 		where M.tx_hash in (%s)`, hash_list_str)
 	}
 
-	msgs, err := queryMessagesImpl(query, conn, settings, store)
+	msgs, err := queryMessagesImpl(query, conn, settings)
 	if err != nil {
 		return models.IndexError{Code: 500, Message: err.Error()}
+	}
+	if store == nil {
+		if err := finalizeMessages(msgs, nil, settings); err != nil {
+			return models.IndexError{Code: 500, Message: err.Error()}
+		}
 	}
 	for _, msg := range msgs {
 		if msg.Direction == "in" {
@@ -665,7 +727,7 @@ func (db *DbClient) QueryTransactions(
 		}
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -785,6 +847,12 @@ func (db *DbClient) QueryTransactions(
 			return nil, nil, models.IndexError{Code: 500, Message: eerr.Error()}
 		}
 	}
+	if db.Kvrocks != nil {
+		release()
+		if eerr := finalizeTransactionSliceFromKvrocks(txs, nil, db.Kvrocks, settings); eerr != nil {
+			return nil, nil, models.IndexError{Code: 500, Message: eerr.Error()}
+		}
+	}
 
 	book := models.AddressBook{}
 	if !settings.NoAddressBook {
@@ -804,6 +872,7 @@ func (db *DbClient) QueryTransactions(
 		}
 		if len(addr_list) > 0 {
 			if db.Kvrocks != nil {
+				release()
 				book, err = QueryAddressBookImplKvrocks(addr_list, db.Kvrocks, settings)
 			} else {
 				coldConn, cerr := fc.cold()
@@ -824,7 +893,7 @@ func (db *DbClient) QueryAdjacentTransactions(
 	req models.AdjacentTransactionRequest,
 	settings models.RequestSettings,
 ) ([]models.Transaction, models.AddressBook, error) {
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
@@ -868,6 +937,12 @@ func (db *DbClient) QueryAdjacentTransactions(
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
 	sort.Slice(txs, func(i, j int) bool { return txs[i].Lt < txs[j].Lt })
+	if db.Kvrocks != nil {
+		release()
+		if eerr := finalizeTransactionSliceFromKvrocks(txs, nil, db.Kvrocks, settings); eerr != nil {
+			return nil, nil, models.IndexError{Code: 500, Message: eerr.Error()}
+		}
+	}
 
 	book := models.AddressBook{}
 	if !settings.NoAddressBook {
@@ -887,6 +962,7 @@ func (db *DbClient) QueryAdjacentTransactions(
 		}
 		if len(addr_list) > 0 {
 			if db.Kvrocks != nil {
+				release()
 				book, err = QueryAddressBookImplKvrocks(addr_list, db.Kvrocks, settings)
 			} else {
 				coldConn, cerr := fc.cold()
@@ -910,7 +986,7 @@ func (db *DbClient) QueryTransactionsExternalHashes(ctx context.Context, txIDs [
 		return nil, nil
 	}
 
-	fc, release, err := db.acquireFed(context.Background())
+	fc, release, err := db.acquireFedForRequest(settings)
 	if err != nil {
 		return nil, models.IndexError{Code: 500, Message: err.Error()}
 	}

--- a/ton-index-go/index/crud/crud_vesting.go
+++ b/ton-index-go/index/crud/crud_vesting.go
@@ -51,11 +51,11 @@ func (db *DbClient) QueryVestingContracts(
 		return vestings, book, nil
 	}
 
-	conn, err := db.Pool.Acquire(context.Background())
+	conn, releaseConn, err := acquireConnForRequest(db.Pool, settings)
 	if err != nil {
 		return nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 	}
-	defer conn.Release()
+	defer releaseConn()
 
 	query, err := buildVestingContractsQuery(req, settings)
 	if err != nil {

--- a/ton-index-go/index/crud/database.go
+++ b/ton-index-go/index/crud/database.go
@@ -81,6 +81,10 @@ func makePool(dsn string, maxconns int, minconns int) (*pgxpool.Pool, error) {
 	if minconns > 0 {
 		config.MinConns = int32(minconns)
 	}
+	if config.ConnConfig.RuntimeParams == nil {
+		config.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	config.ConnConfig.RuntimeParams["jit"] = "off"
 	config.HealthCheckPeriod = 60 * time.Second
 	config.AfterConnect = afterConnectRegisterTypes
 	return pgxpool.NewWithConfig(context.Background(), config)

--- a/ton-index-go/index/crud/hotcold.go
+++ b/ton-index-go/index/crud/hotcold.go
@@ -2,23 +2,42 @@ package crud
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type fedConns struct {
-	db        *DbClient
-	ctx       context.Context // acquisition context for this request's lifetime
-	split     hotColdSplit
-	federated bool
+	db             *DbClient
+	ctx            context.Context
+	acquireTimeout time.Duration
+	split          hotColdSplit
+	federated      bool
 
 	hotConn, coldConn *pgxpool.Conn // nil until first use
+}
+
+func (fc *fedConns) acquireContext() (context.Context, context.CancelFunc) {
+	base := fc.ctx
+	if base == nil {
+		base = context.Background()
+	}
+	if fc.acquireTimeout > 0 {
+		return context.WithTimeout(base, fc.acquireTimeout)
+	}
+	return context.WithCancel(base)
+}
+
+func (fc *fedConns) acquire(pool *pgxpool.Pool) (*pgxpool.Conn, error) {
+	ctx, cancel := fc.acquireContext()
+	defer cancel()
+	return pool.Acquire(ctx)
 }
 
 // cold returns the default-pool connection, acquiring it on first use.
 func (fc *fedConns) cold() (*pgxpool.Conn, error) {
 	if fc.coldConn == nil {
-		c, err := fc.db.Pool.Acquire(fc.ctx)
+		c, err := fc.acquire(fc.db.Pool)
 		if err != nil {
 			return nil, err
 		}
@@ -34,7 +53,7 @@ func (fc *fedConns) hot() (*pgxpool.Conn, error) {
 		return fc.cold()
 	}
 	if fc.hotConn == nil {
-		c, err := fc.db.HotPool.Acquire(fc.ctx)
+		c, err := fc.acquire(fc.db.HotPool)
 		if err != nil {
 			return nil, err
 		}
@@ -68,11 +87,15 @@ func (db *DbClient) acquireFed(ctx context.Context) (*fedConns, func(), error) {
 		fc.split = split
 	}
 	release := func() {
-		if fc.coldConn != nil {
-			fc.coldConn.Release()
+		coldConn := fc.coldConn
+		hotConn := fc.hotConn
+		fc.coldConn = nil
+		fc.hotConn = nil
+		if coldConn != nil {
+			coldConn.Release()
 		}
-		if fc.hotConn != nil && fc.hotConn != fc.coldConn {
-			fc.hotConn.Release()
+		if hotConn != nil && hotConn != coldConn {
+			hotConn.Release()
 		}
 	}
 	return fc, release, nil

--- a/ton-index-go/index/crud/split.go
+++ b/ton-index-go/index/crud/split.go
@@ -49,6 +49,13 @@ func newSplitProvider(hot *pgxpool.Pool, ttl time.Duration) *SplitProvider {
 	return &SplitProvider{hot: hot, ttl: ttl}
 }
 
+func splitRefreshBackoff(ttl time.Duration) time.Duration {
+	if ttl > 30*time.Second {
+		return ttl
+	}
+	return 30 * time.Second
+}
+
 // Split returns the shared routing boundary
 func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 
@@ -59,11 +66,33 @@ func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 	}
 
 	if entry != nil {
-		// Another goroutine is refreshing, leave update to it, return current values
-		if !s.refreshMu.TryLock() {
-			// Reload in case the refresh completed
-			return s.entry.Load().val, nil
+		// Serve stale split immediately and refresh in the background. The split
+		// changes slowly, while API requests should not inherit a slow split read.
+		if s.refreshMu.TryLock() {
+			go func() {
+				defer s.refreshMu.Unlock()
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				val, err := querySplit(ctx, s.hot)
+				if err != nil {
+					log.Printf(
+						"hot/cold: split refresh failed, serving stale boundary: %v",
+						err,
+					)
+					s.entry.Store(&splitEntry{
+						val:       entry.val,
+						expiresAt: time.Now().Add(splitRefreshBackoff(s.ttl)),
+					})
+					return
+				}
+				s.entry.Store(&splitEntry{
+					val:       val,
+					expiresAt: time.Now().Add(s.ttl),
+				})
+			}()
 		}
+		return entry.val, nil
 	} else {
 		s.refreshMu.Lock()
 	}
@@ -83,6 +112,10 @@ func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 				"hot/cold: split refresh failed, serving stale boundary: %v",
 				err,
 			)
+			s.entry.Store(&splitEntry{
+				val:       old.val,
+				expiresAt: time.Now().Add(splitRefreshBackoff(s.ttl)),
+			})
 			return old.val, nil
 		}
 		return hotColdSplit{}, err

--- a/ton-index-go/index/crud/split.go
+++ b/ton-index-go/index/crud/split.go
@@ -49,13 +49,6 @@ func newSplitProvider(hot *pgxpool.Pool, ttl time.Duration) *SplitProvider {
 	return &SplitProvider{hot: hot, ttl: ttl}
 }
 
-func splitRefreshBackoff(ttl time.Duration) time.Duration {
-	if ttl > 30*time.Second {
-		return ttl
-	}
-	return 30 * time.Second
-}
-
 // Split returns the shared routing boundary
 func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 
@@ -66,33 +59,11 @@ func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 	}
 
 	if entry != nil {
-		// Serve stale split immediately and refresh in the background. The split
-		// changes slowly, while API requests should not inherit a slow split read.
-		if s.refreshMu.TryLock() {
-			go func() {
-				defer s.refreshMu.Unlock()
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-				defer cancel()
-
-				val, err := querySplit(ctx, s.hot)
-				if err != nil {
-					log.Printf(
-						"hot/cold: split refresh failed, serving stale boundary: %v",
-						err,
-					)
-					s.entry.Store(&splitEntry{
-						val:       entry.val,
-						expiresAt: time.Now().Add(splitRefreshBackoff(s.ttl)),
-					})
-					return
-				}
-				s.entry.Store(&splitEntry{
-					val:       val,
-					expiresAt: time.Now().Add(s.ttl),
-				})
-			}()
+		// Another goroutine is refreshing, leave update to it, return current values
+		if !s.refreshMu.TryLock() {
+			// Reload in case the refresh completed
+			return s.entry.Load().val, nil
 		}
-		return entry.val, nil
 	} else {
 		s.refreshMu.Lock()
 	}
@@ -112,10 +83,6 @@ func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 				"hot/cold: split refresh failed, serving stale boundary: %v",
 				err,
 			)
-			s.entry.Store(&splitEntry{
-				val:       old.val,
-				expiresAt: time.Now().Add(splitRefreshBackoff(s.ttl)),
-			})
 			return old.val, nil
 		}
 		return hotColdSplit{}, err

--- a/ton-index-go/index/crud/split.go
+++ b/ton-index-go/index/crud/split.go
@@ -51,7 +51,6 @@ func newSplitProvider(hot *pgxpool.Pool, ttl time.Duration) *SplitProvider {
 
 // Split returns the shared routing boundary
 func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
-
 	now := time.Now()
 	entry := s.entry.Load()
 	if entry != nil && now.Before(entry.expiresAt) {
@@ -59,41 +58,59 @@ func (s *SplitProvider) Split(ctx context.Context) (hotColdSplit, error) {
 	}
 
 	if entry != nil {
-		// Another goroutine is refreshing, leave update to it, return current values
-		if !s.refreshMu.TryLock() {
-			// Reload in case the refresh completed
-			return s.entry.Load().val, nil
+		if s.refreshMu.TryLock() {
+			go s.refresh(entry.val)
 		}
-	} else {
-		s.refreshMu.Lock()
+		return entry.val, nil
 	}
+
+	s.refreshMu.Lock()
 	defer s.refreshMu.Unlock()
 
 	// Another goroutine may have refreshed while we waited for refreshMu.
-	now = time.Now()
 	old := s.entry.Load()
-	if old != nil && now.Before(old.expiresAt) {
+	if old != nil {
 		return old.val, nil
 	}
 
 	val, err := querySplit(ctx, s.hot)
 	if err != nil {
-		if old != nil {
-			log.Printf(
-				"hot/cold: split refresh failed, serving stale boundary: %v",
-				err,
-			)
-			return old.val, nil
-		}
 		return hotColdSplit{}, err
 	}
 
+	s.store(val)
+	return val, nil
+}
+
+func (s *SplitProvider) store(val hotColdSplit) {
 	s.entry.Store(&splitEntry{
 		val:       val,
 		expiresAt: time.Now().Add(s.ttl),
 	})
+}
 
-	return val, nil
+func (s *SplitProvider) refresh(stale hotColdSplit) {
+	defer s.refreshMu.Unlock()
+
+	time.Sleep(time.Second)
+
+	timeout := s.ttl
+	if timeout < 3*time.Second {
+		timeout = 3 * time.Second
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	val, err := querySplit(ctx, s.hot)
+	if err != nil {
+		log.Printf(
+			"hot/cold: split refresh failed, serving stale boundary: %v",
+			err,
+		)
+		s.store(stale)
+		return
+	}
+	s.store(val)
 }
 
 func querySplit(ctx context.Context, hot *pgxpool.Pool) (hotColdSplit, error) {

--- a/ton-index-go/index/services/tasks.go
+++ b/ton-index-go/index/services/tasks.go
@@ -59,42 +59,56 @@ func (manager *TaskManager) Start(ctx context.Context) {
 	go manager.run(ctx)
 }
 
+func (manager *TaskManager) requeueIfPossible(tasks []BackgroundTask) {
+	select {
+	case manager.taskChannel <- tasks:
+	default:
+		log.Printf("Task channel is full, dropping %d background tasks", len(tasks))
+	}
+}
+
 func (manager *TaskManager) loop(ctx context.Context) {
-	tasks := <-manager.taskChannel
+	var tasks []BackgroundTask
+	select {
+	case tasks = <-manager.taskChannel:
+	case <-ctx.Done():
+		return
+	}
 	conn, err := manager.pool.Acquire(ctx)
 	if err != nil {
 		log.Printf("Error acquiring connection to create tasks: %v", err)
-		manager.taskChannel <- tasks
+		manager.requeueIfPossible(tasks)
+		return
 	}
 	defer conn.Release()
 	tx, err := conn.Begin(ctx)
 	if err != nil {
 		log.Printf("Error beginning transaction to create tasks: %v", err)
-		manager.taskChannel <- tasks
+		manager.requeueIfPossible(tasks)
+		return
 	}
-	tx_failed := false
+	defer func() {
+		_ = tx.Rollback(context.Background())
+	}()
 	for _, task := range tasks {
 		_, err := tx.Exec(ctx, "INSERT INTO _background_tasks (type, data, status) "+
 			"VALUES ($1, $2, 'ready') ON CONFLICT DO NOTHING", task.Type, task.Data)
 		if err != nil {
 			log.Printf("Error inserting task: %v", err)
-			tx.Rollback(ctx)
-			manager.taskChannel <- tasks
-			tx_failed = true
-			break
+			manager.requeueIfPossible(tasks)
+			return
 		}
 	}
-	if !tx_failed {
-		err = tx.Commit(ctx)
-		if err != nil {
-			log.Printf("Error committing transaction to create tasks: %v", err)
-			manager.taskChannel <- tasks
-		}
+	err = tx.Commit(ctx)
+	if err != nil {
+		log.Printf("Error committing transaction to create tasks: %v", err)
+		manager.requeueIfPossible(tasks)
+		return
 	}
 }
 
 func (manager *TaskManager) run(ctx context.Context) {
-	for {
+	for ctx.Err() == nil {
 		manager.loop(ctx)
 	}
 }

--- a/ton-index-go/main.go
+++ b/ton-index-go/main.go
@@ -70,6 +70,16 @@ func validateDirection(direction *string) error {
 	return nil
 }
 
+func validateTransactionsDirection(req models.TransactionsRequest) error {
+	if err := validateDirection(req.Direction); err != nil {
+		return err
+	}
+	if req.Direction != nil && len(req.MessageHash) == 0 {
+		return models.IndexError{Code: 422, Message: "direction can be specified only with msg_hash"}
+	}
+	return nil
+}
+
 var actionTypeFilterRegexp = regexp.MustCompile(`^[A-Za-z0-9_.]+$`)
 var nftIndexRegexp = regexp.MustCompile(`^[0-9]+$`)
 
@@ -282,6 +292,9 @@ func GetTransactions(c *fiber.Ctx) error {
 	if err := c.QueryParser(&req); err != nil {
 		return models.IndexError{Code: 422, Message: err.Error()}
 	}
+	if err := validateTransactionsDirection(req); err != nil {
+		return err
+	}
 	txs, book, err := pool.QueryTransactions(req, request_settings)
 	if err != nil {
 		return err
@@ -443,6 +456,9 @@ func GetTransactionsByMessage(c *fiber.Ctx) error {
 
 	if err := c.QueryParser(&req); err != nil {
 		return models.IndexError{Code: 422, Message: err.Error()}
+	}
+	if err := validateDirection(req.Direction); err != nil {
+		return err
 	}
 	if req.BodyHash == nil && req.MessageHash == nil && req.Opcode == nil {
 		return models.IndexError{Code: 422, Message: "at least one of msg_hash, body_hash, opcode should be specified"}


### PR DESCRIPTION
- Added timeout-aware PG connection acquisition using `settings.Timeout`.
- Replaced many `Acquire(context.Background())` calls in CRUD paths.
- Made federated hot/cold connection release safe for early release.
- Released PG connections before Kvrocks enrichment where possible.
- Added timeouts to several Kvrocks/SQL helper reads.
- Main impact: less pool exhaustion from requests holding idle PG connections while waiting on Kvrocks.