### PR TITLE
messages index move from created_lt to coalesce(created_lt, tx_lt)

### DIFF
--- a/ton-index-go/index/crud/crud_actions_v2.go
+++ b/ton-index-go/index/crud/crud_actions_v2.go
@@ -123,7 +123,7 @@ func (db *DbClient) QueryActionsV2(
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
-		} else {
+		} else if !settings.NoAddressBook || !settings.NoMetadata {
 			coldConn, cerr := fc.cold()
 			if cerr != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}
@@ -234,8 +234,6 @@ func queryActionsRouted(
 			endUtime:   (*uint64)(req.EndUtime),
 			orderByNow: orderByNow,
 			sortDesc:   sortOrder == "desc",
-			// trace_end_lt/trace_end_utime are NOT NULL.
-			canHaveNullKeys: false,
 		}
 		dec = classifyRoute(w, fc.split, fc.utimeMargin)
 
@@ -483,18 +481,23 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 		}
 		filter_list = append(filter_list, fmt.Sprintf("%s <= %d", field, *v))
 	}
-	if v := req.AccountAddress; v != nil {
+	if v := req.AccountAddress; join_accounts && v != nil {
 		filter_str := fmt.Sprintf("AA.account = '%s'::tonaddr", v.FilterString())
 		filter_list = append(filter_list, filter_str)
 
-		from_query = `action_accounts as AA join lateral (
-			select *
-			from actions as A
-			where A.trace_id = AA.trace_id
-				and A.action_id = AA.action_id
-				and A.trace_mc_seqno_end = AA.trace_mc_seqno_end
-			limit 1
-		) as A on true`
+		action_accounts_from := `action_accounts as AA`
+		if trace_filter := filterByArray("trace_id", req.TraceId); len(trace_filter) > 0 {
+			// Limit action_accounts before the lateral join for account+trace_id.
+			action_accounts_from = fmt.Sprintf("(select * from action_accounts where %s) as AA", trace_filter)
+		}
+		from_query = action_accounts_from + ` join lateral (
+				select *
+				from actions as A
+				where A.trace_id = AA.trace_id
+					and A.action_id = AA.action_id
+					and A.trace_mc_seqno_end = AA.trace_mc_seqno_end
+				limit 1
+			) as A on true`
 		if order_by_now {
 			clmn_query = `distinct on (AA.account, AA.trace_end_utime, AA.trace_id, AA.action_end_utime, AA.action_id) ` + clmn_query_default
 		} else {
@@ -505,23 +508,26 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 		filter_str := filterByArray("T.hash", v)
 		if len(filter_str) > 0 {
 			filter_list = append(filter_list, filter_str)
+			from_query += ` join transactions as T on A.trace_id = T.trace_id and A.tx_hashes @> array[T.hash::tonhash]`
 		}
-		from_query = `actions as A join transactions as T on A.trace_id = T.trace_id and A.tx_hashes @> array[T.hash::tonhash]`
-		if order_by_now {
-			clmn_query = `distinct on (A.trace_end_utime, A.trace_id, A.end_utime, A.action_id) ` + clmn_query_default
-		} else {
-			clmn_query = `distinct on (A.trace_end_lt, A.trace_id, A.end_lt, A.action_id) ` + clmn_query_default
+		if len(filter_str) > 0 && !join_accounts {
+			if order_by_now {
+				clmn_query = `distinct on (A.trace_end_utime, A.trace_id, A.end_utime, A.action_id) ` + clmn_query_default
+			} else {
+				clmn_query = `distinct on (A.trace_end_lt, A.trace_id, A.end_lt, A.action_id) ` + clmn_query_default
+			}
 		}
 	}
 	if v := req.MessageHash; len(v) > 0 {
 		filter_str := fmt.Sprintf("(%s or %s)", filterByArray("M.msg_hash", v), filterByArray("M.msg_hash_norm", v))
 		filter_list = append(filter_list, filter_str)
-
-		from_query = `actions as A join messages as M on A.trace_id = M.trace_id and array[M.tx_hash::tonhash] <@ A.tx_hashes`
-		if order_by_now {
-			clmn_query = `distinct on (A.trace_end_utime, A.trace_id, A.end_utime, A.action_id) ` + clmn_query_default
-		} else {
-			clmn_query = `distinct on (A.trace_end_lt, A.trace_id, A.end_lt, A.action_id) ` + clmn_query_default
+		from_query += ` join messages as M on A.trace_id = M.trace_id and array[M.tx_hash::tonhash] <@ A.tx_hashes`
+		if !join_accounts {
+			if order_by_now {
+				clmn_query = `distinct on (A.trace_end_utime, A.trace_id, A.end_utime, A.action_id) ` + clmn_query_default
+			} else {
+				clmn_query = `distinct on (A.trace_end_lt, A.trace_id, A.end_lt, A.action_id) ` + clmn_query_default
+			}
 		}
 	}
 	if v := req.IncludeActionTypes; len(v) > 0 {
@@ -534,35 +540,17 @@ func actionsQueryPartsV2(req models.ActionRequest, sort_order string) actionsQue
 	}
 	if v := req.McSeqno; v != nil {
 		filter_list = append(filter_list, fmt.Sprintf("A.trace_mc_seqno_end = %d", *v))
-		from_query = `actions as A`
-		clmn_query = clmn_query_default
 	}
 	if v := req.ActionId; v != nil {
-		from_query = `actions as A`
 		filter_str := filterByArray("A.action_id", v)
 		if len(filter_str) > 0 {
-			filter_list = []string{filter_str}
+			filter_list = append(filter_list, filter_str)
 		}
-		clmn_query = clmn_query_default
 	}
 	if v := req.TraceId; v != nil {
-		trace_filter := filterByArray("trace_id", v)
-		if len(trace_filter) > 0 {
-			joined_accounts := strings.Contains(from_query, "action_accounts")
-			if join_accounts && joined_accounts {
-				// Limit action_accounts before join to keep account+trace_id requests fast.
-				from_query = fmt.Sprintf("(select * from action_accounts where %s) as AA join actions as A on A.trace_id = AA.trace_id and A.action_id = AA.action_id and A.trace_mc_seqno_end = AA.trace_mc_seqno_end", trace_filter)
-			} else {
-				filter_str := filterByArray("A.trace_id", v)
-				if len(filter_str) > 0 {
-					if join_accounts {
-						filter_list = append(filter_list, filter_str)
-					} else {
-						from_query = `actions as A`
-						filter_list = []string{filter_str}
-					}
-				}
-			}
+		filter_str := filterByArray("A.trace_id", v)
+		if len(filter_str) > 0 {
+			filter_list = append(filter_list, filter_str)
 		}
 	}
 	if strings.Contains(from_query, "action_accounts") {

--- a/ton-index-go/index/crud/crud_blocks.go
+++ b/ton-index-go/index/crud/crud_blocks.go
@@ -123,8 +123,6 @@ func blocksRouteWindow(req models.BlocksRequest, sortOrder string) routeWindow {
 		endUtime:   (*uint64)(utime_req.EndUtime),
 		orderByNow: true,
 		sortDesc:   sortOrder == "desc",
-		// gen_utime is non-null in models.Block.
-		canHaveNullKeys: false,
 	}
 }
 

--- a/ton-index-go/index/crud/crud_jettons.go
+++ b/ton-index-go/index/crud/crud_jettons.go
@@ -254,13 +254,12 @@ func jettonBurnsQueryParts(req models.JettonBurnRequest, sortOrder string) txLtL
 // jettonRouteWindow builds the shared transfer/burn router window.
 func jettonRouteWindow(startLt, endLt *uint64, startUtime, endUtime *models.UtimeType, orderByNow, sortDesc bool) routeWindow {
 	return routeWindow{
-		startLt:         startLt,
-		endLt:           endLt,
-		startUtime:      (*uint64)(startUtime),
-		endUtime:        (*uint64)(endUtime),
-		orderByNow:      orderByNow,
-		sortDesc:        sortDesc,
-		canHaveNullKeys: false,
+		startLt:    startLt,
+		endLt:      endLt,
+		startUtime: (*uint64)(startUtime),
+		endUtime:   (*uint64)(endUtime),
+		orderByNow: orderByNow,
+		sortDesc:   sortDesc,
 	}
 }
 

--- a/ton-index-go/index/crud/crud_messages.go
+++ b/ton-index-go/index/crud/crud_messages.go
@@ -12,21 +12,24 @@ import (
 	"github.com/toncenter/ton-indexer/ton-index-go/index/parse"
 )
 
+const messageOrderLtExpr = "COALESCE(M.created_lt, M.tx_lt)"
+
 const messagesRestColumns = `M.trace_id, M.source, M.destination, M.value,
 	M.value_extra_currencies, M.fwd_fee, M.ihr_fee, M.extra_flags, M.created_lt, M.created_at, M.opcode, M.ihr_disabled, M.bounce,
 	M.bounced, M.import_fee, M.body_hash, M.init_state_hash, M.msg_hash_norm`
 
-const messagesClmnQuery = `'', 0, M.msg_hash, '', ` + messagesRestColumns + `,
+const messagesClmnQuery = `'', ` + messageOrderLtExpr + ` as message_order_key, M.msg_hash, '', ` + messagesRestColumns + `,
 	(array_agg(M.tx_hash ORDER BY M.tx_lt) FILTER (WHERE M.direction='in'))[1] as in_tx_hash,
 	(array_agg(M.tx_hash ORDER BY M.tx_lt) FILTER (WHERE M.direction='out'))[1] as out_tx_hash`
 
-const messagesGroupBy = ` group by M.msg_hash, ` + messagesRestColumns
+const messagesGroupBy = ` group by M.msg_hash, ` + messageOrderLtExpr + `, ` + messagesRestColumns
 
 // msgQueryParts holds the shared pieces of a messages listing query.
 type msgQueryParts struct {
 	filterList []string
 	args       []any
 	orderBy    string
+	outerOrder string
 	orderByNow bool
 	useKvrocks bool
 }
@@ -67,48 +70,72 @@ func messagesQueryParts(req models.MessageRequest, sortOrder string, useKvrocks 
 		filter_list = append(filter_list, fmt.Sprintf("M.body_hash = '%s'", v.FilterString()))
 	}
 
-	order_col := "M.created_lt"
+	orderCol := messageOrderLtExpr
 	orderByNow := false
 	if v := utime_req.StartUtime; v != nil {
 		filter_list = append(filter_list, fmt.Sprintf("M.created_at >= %d", *v))
-		order_col = "M.created_at"
+		orderCol = "M.created_at"
 		orderByNow = true
 	}
 	if v := utime_req.EndUtime; v != nil {
 		filter_list = append(filter_list, fmt.Sprintf("M.created_at <= %d", *v))
-		order_col = "M.created_at"
+		orderCol = "M.created_at"
 		orderByNow = true
 	}
+	hasLtBounds := lt_req.StartLt != nil || lt_req.EndLt != nil
+	if hasLtBounds {
+		// Keep the public bounds semantics: external-in messages still do not
+		// belong to created_lt windows. Compare K after excluding them so the
+		// expression indexes can satisfy the same request efficiently.
+		filter_list = append(filter_list, "M.created_lt is not NULL")
+	}
 	if v := lt_req.StartLt; v != nil {
-		filter_list = append(filter_list, fmt.Sprintf("M.created_lt >= %d", *v))
+		filter_list = append(filter_list, fmt.Sprintf("%s >= %d", messageOrderLtExpr, *v))
 	}
 	if v := lt_req.EndLt; v != nil {
-		filter_list = append(filter_list, fmt.Sprintf("M.created_lt <= %d", *v))
+		filter_list = append(filter_list, fmt.Sprintf("%s <= %d", messageOrderLtExpr, *v))
 	}
-	if v := req.ExcludeExternals; v != nil && *v {
-		filter_list = append(filter_list, order_col+" is not NULL")
+	if v := req.ExcludeExternals; v != nil && *v && !hasLtBounds {
+		filter_list = append(filter_list, "M.created_lt is not NULL")
 	}
 	if v := req.OnlyExternals; v != nil && *v {
-		filter_list = append(filter_list, order_col+" is NULL")
+		filter_list = append(filter_list, "M.created_lt is NULL")
 	}
 
-	// With one address filter, lead ORDER BY with that address column so Postgres
-	// can use the composite (address, created_lt) index. The created_at path has
-	// no matching composite index.
-	addressFirst := ""
-	if req.Destination != nil && req.Source == nil {
-		addressFirst = "M.destination"
-	} else if req.Source != nil && req.Destination == nil {
-		addressFirst = "M.source"
+	// Lead LT ordering with equality-constrained columns so each query shape
+	// exactly matches one of the composite COALESCE(created_lt, tx_lt) indexes.
+	orderCols := []string{}
+	if !orderByNow {
+		switch {
+		case req.Destination != nil && req.Opcode != nil:
+			orderCols = append(orderCols, "M.destination", "M.opcode")
+		case req.Source != nil:
+			orderCols = append(orderCols, "M.source")
+		case req.Destination != nil:
+			orderCols = append(orderCols, "M.destination")
+		case req.Opcode != nil:
+			orderCols = append(orderCols, "M.opcode")
+		}
+	}
+	orderCols = append(orderCols, orderCol, "M.msg_hash")
+	for i := range orderCols {
+		orderCols[i] += " " + sortOrder
 	}
 
-	var orderby_query string
-	if addressFirst != "" && !orderByNow {
-		orderby_query = fmt.Sprintf(" order by %s %s, %s %s, M.msg_hash %s", addressFirst, sortOrder, order_col, sortOrder, sortOrder)
-	} else {
-		orderby_query = fmt.Sprintf(" order by %s %s, M.msg_hash %s", order_col, sortOrder, sortOrder)
+	outerOrderCol := "MM.message_order_key"
+	if orderByNow {
+		outerOrderCol = "MM.created_at"
 	}
-	return msgQueryParts{filterList: filter_list, args: args, orderBy: orderby_query, orderByNow: orderByNow, useKvrocks: useKvrocks}
+	outerOrder := fmt.Sprintf(" order by %s %s, MM.msg_hash %s", outerOrderCol, sortOrder, sortOrder)
+
+	return msgQueryParts{
+		filterList: filter_list,
+		args:       args,
+		orderBy:    " order by " + strings.Join(orderCols, ", "),
+		outerOrder: outerOrder,
+		orderByNow: orderByNow,
+		useKvrocks: useKvrocks,
+	}
 }
 
 // messagesPageInner builds one grouped page without hot/cold seam bounds.
@@ -124,11 +151,11 @@ func buildMessagesOffsetQuery(p msgQueryParts, offset, limit int) string {
 	limit_query := fmt.Sprintf(" limit %d offset %d", max(1, limit), max(0, offset))
 	inner_query := messagesPageInner(p, p.orderBy+limit_query)
 	if p.useKvrocks {
-		return `select MM.*, NULL::tonhash, NULL::text, NULL::tonhash, NULL::text from (` + inner_query + `) as MM;`
+		return `select MM.*, NULL::tonhash, NULL::text, NULL::tonhash, NULL::text from (` + inner_query + `) as MM` + p.outerOrder + `;`
 	}
 	return `select MM.*, B.*, I.* from (` + inner_query + `) as MM
 	left join message_contents as B on MM.body_hash = B.hash
-	left join message_contents as I on MM.init_state_hash = I.hash;`
+	left join message_contents as I on MM.init_state_hash = I.hash` + p.outerOrder + `;`
 }
 
 func messagePtrs(msgs []models.Message) []*models.Message {
@@ -240,22 +267,9 @@ func queryMessagesImpl(query string, conn *pgxpool.Conn, settings models.Request
 	return msgs, nil
 }
 
-// messagesCanHaveNullKeys reports whether a page can contain external-in messages
-func messagesCanHaveNullKeys(req models.MessageRequest) bool {
-	if req.ExcludeExternals != nil && *req.ExcludeExternals {
-		return false
-	}
-	if req.Source != nil && !req.Source.IsAddressNone() {
-		return false
-	}
-	if req.Direction != nil && *req.Direction == "out" {
-		return false
-	}
-	return true
-}
-
-// messageOrderKey returns nil for external messages with NULL created_lt; that
-// forces cold fallback during hot-page verification.
+// messageOrderKey returns the actual page-order key selected into the hidden
+// Message.TxLt slot. LT pages use COALESCE(created_lt, tx_lt), while utime
+// pages continue to use created_at.
 func messageOrderKey(orderByNow bool) func(*models.Message) *uint64 {
 	if orderByNow {
 		return func(m *models.Message) *uint64 {
@@ -266,7 +280,21 @@ func messageOrderKey(orderByNow bool) func(*models.Message) *uint64 {
 			return &v
 		}
 	}
-	return func(m *models.Message) *uint64 { return m.CreatedLt }
+	return func(m *models.Message) *uint64 {
+		v := uint64(m.TxLt)
+		return &v
+	}
+}
+
+func messageRouteWindow(req models.MessageRequest, parts msgQueryParts, sortOrder string) routeWindow {
+	return routeWindow{
+		startLt:    req.StartLt,
+		endLt:      req.EndLt,
+		startUtime: (*uint64)(req.StartUtime),
+		endUtime:   (*uint64)(req.EndUtime),
+		orderByNow: parts.orderByNow,
+		sortDesc:   sortOrder == "desc",
+	}
 }
 
 // queryMessagesRouted fetches one grouped page via the hot/cold router.
@@ -284,18 +312,10 @@ func queryMessagesRouted(
 	dec := routeCold
 	var floor uint64
 	if fc.federated {
-		w := routeWindow{
-			startLt:         req.StartLt,
-			endLt:           req.EndLt,
-			startUtime:      (*uint64)(req.StartUtime),
-			endUtime:        (*uint64)(req.EndUtime),
-			orderByNow:      parts.orderByNow,
-			sortDesc:        sortOrder == "desc",
-			canHaveNullKeys: messagesCanHaveNullKeys(req),
-		}
+		w := messageRouteWindow(req, parts, sortOrder)
 		dec = classifyRoute(w, fc.split, fc.utimeMargin)
 
-		// created_lt >= split.Lt keeps the whole grouped message above the floor.
+		// message_order_key >= split.Lt keeps the whole grouped message above the floor.
 		floor = fc.split.Lt
 		if parts.orderByNow {
 			floor = fc.split.Utime + fc.utimeMargin
@@ -306,6 +326,10 @@ func queryMessagesRouted(
 		func(conn *pgxpool.Conn) ([]models.Message, error) { return fetch(query, conn) },
 		messageOrderKey(parts.orderByNow), limit, floor)
 	return msgs, err
+}
+
+func needsPostgresMessageEnrichment(settings models.RequestSettings) bool {
+	return !settings.NoAddressBook || !settings.NoMetadata
 }
 
 func (db *DbClient) QueryMessages(
@@ -377,7 +401,7 @@ func (db *DbClient) QueryMessages(
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
-		} else {
+		} else if needsPostgresMessageEnrichment(settings) {
 			coldConn, cerr := fc.cold()
 			if cerr != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: cerr.Error()}

--- a/ton-index-go/index/crud/crud_nft.go
+++ b/ton-index-go/index/crud/crud_nft.go
@@ -339,13 +339,12 @@ func queryNFTTransfersRouted(
 	var floor uint64
 	if fc.federated {
 		w := routeWindow{
-			startLt:         req.StartLt,
-			endLt:           req.EndLt,
-			startUtime:      (*uint64)(req.StartUtime),
-			endUtime:        (*uint64)(req.EndUtime),
-			orderByNow:      parts.orderByNow,
-			sortDesc:        sortOrder == "desc",
-			canHaveNullKeys: false, // tx_lt/tx_now are never NULL
+			startLt:    req.StartLt,
+			endLt:      req.EndLt,
+			startUtime: (*uint64)(req.StartUtime),
+			endUtime:   (*uint64)(req.EndUtime),
+			orderByNow: parts.orderByNow,
+			sortDesc:   sortOrder == "desc",
 		}
 		dec = classifyRoute(w, fc.split, fc.utimeMargin)
 

--- a/ton-index-go/index/crud/crud_traces.go
+++ b/ton-index-go/index/crud/crud_traces.go
@@ -472,13 +472,12 @@ func queryTracesRouted(req models.TracesRequest, settings models.RequestSettings
 	var floor uint64
 	if fc.federated {
 		w := routeWindow{
-			startLt:         req.StartLt,
-			endLt:           req.EndLt,
-			startUtime:      (*uint64)(req.StartUtime),
-			endUtime:        (*uint64)(req.EndUtime),
-			orderByNow:      orderByNow,
-			sortDesc:        sortOrder == "desc",
-			canHaveNullKeys: false,
+			startLt:    req.StartLt,
+			endLt:      req.EndLt,
+			startUtime: (*uint64)(req.StartUtime),
+			endUtime:   (*uint64)(req.EndUtime),
+			orderByNow: orderByNow,
+			sortDesc:   sortOrder == "desc",
 		}
 		dec = classifyRoute(w, fc.split, fc.utimeMargin)
 
@@ -816,20 +815,6 @@ func (db *DbClient) QueryTraces(
 	}
 	defer release()
 
-	if seqno := req.McSeqno; seqno != nil {
-		conn, err := fc.connForSeqno(uint64(*seqno))
-		if err != nil {
-			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
-		}
-		exists, err := queryBlockExists(*seqno, conn, settings)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		if !exists {
-			return nil, nil, nil, models.IndexError{Code: 404, Message: fmt.Sprintf("masterchain block %d not found", *seqno)}
-		}
-	}
-
 	// offset > 0 keeps legacy offset/limit paging, offset == 0 uses the fast keyset cascade.
 	offset := 0
 	if lim_req.Offset != nil {
@@ -838,8 +823,36 @@ func (db *DbClient) QueryTraces(
 	// Prefer order by lt if any lt filter passed.
 	orderByNow := tracesOrderByNow(req)
 
-	// Enrich from the same side that served the routed page.
-	traces, servedCold, err := queryTracesRouted(req, settings, sortOrder, fc, offset, int(limit), orderByNow)
+	// The writer publishes a guarded split so a trace and its related rows are
+	// retained on the side that owns mc_seqno_end.
+	var seqnoConn *pgxpool.Conn
+	if seqno := req.McSeqno; seqno != nil {
+		seqnoConn, err = fc.connForSeqno(uint64(*seqno))
+		if err != nil {
+			return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
+		}
+		exists, existsErr := queryBlockExists(*seqno, seqnoConn, settings)
+		if existsErr != nil {
+			return nil, nil, nil, existsErr
+		}
+		if !exists {
+			return nil, nil, nil, models.IndexError{Code: 404, Message: fmt.Sprintf("masterchain block %d not found", *seqno)}
+		}
+	}
+
+	var traces []models.Trace
+	servedCold := false
+	if seqno := req.McSeqno; seqno != nil {
+		query := buildTracesOffsetQuery(req, sortOrder, offset, int(limit), orderByNow)
+		if settings.DebugRequest {
+			log.Println("Debug mc_seqno query:", query)
+		}
+		traces, err = queryTraces(query, seqnoConn, settings)
+		servedCold = fc.coldForSeqno(uint64(*seqno))
+	} else {
+		// Enrich from the same side that served the routed page.
+		traces, servedCold, err = queryTracesRouted(req, settings, sortOrder, fc, offset, int(limit), orderByNow)
+	}
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -847,8 +860,8 @@ func (db *DbClient) QueryTraces(
 		traces = []models.Trace{}
 	}
 
-	// Hot pages may contain seam-spanning traces whose early rows exist only on
-	// cold. Enrich only those traces from cold.
+	// Keep a defensive cold-enrichment fallback for exceptional traces whose
+	// start lies below the published guarded split.
 	hotIdx, coldIdx := []int{}, []int{}
 	for i := range traces {
 		toCold := servedCold
@@ -917,7 +930,7 @@ func (db *DbClient) QueryTraces(
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}
 			}
-		} else {
+		} else if !settings.NoAddressBook || !settings.NoMetadata {
 			cold, err := fc.cold()
 			if err != nil {
 				return nil, nil, nil, models.IndexError{Code: 500, Message: err.Error()}

--- a/ton-index-go/index/crud/crud_transactions.go
+++ b/ton-index-go/index/crud/crud_transactions.go
@@ -707,8 +707,6 @@ func queryTransactionsRouted(
 			endUtime:   (*uint64)(req.EndUtime),
 			orderByNow: parts.orderByNow,
 			sortDesc:   sortOrder == "desc",
-			// Transaction sort keys are never NULL.
-			canHaveNullKeys: false,
 		}
 		dec = classifyRoute(w, fc.split, fc.utimeMargin)
 

--- a/ton-index-go/index/crud/router.go
+++ b/ton-index-go/index/crud/router.go
@@ -19,7 +19,6 @@ type routeWindow struct {
 	startUtime, endUtime *uint64 // bounds on utime axis (from request UtimeParams)
 	orderByNow           bool    // sort axis is utime, not lt
 	sortDesc             bool    // resolved sort order
-	canHaveNullKeys      bool    // messages only: externals with NULL created_lt possible
 }
 
 // classifyRoute picks cold, hot, or hot-with-verification for a paged request.
@@ -41,7 +40,7 @@ func classifyRoute(w routeWindow, s hotColdSplit, utimeMarginSec uint64) routeDe
 	if end != nil && *end < coldFloor {
 		return routeCold
 	}
-	// 2. Lower bound below the floor: window may reach into cold.
+	// 2. Lower bound below the floor: the requested window reaches cold.
 	if start != nil && *start < hotFloor {
 		return routeCold
 	}
@@ -49,17 +48,12 @@ func classifyRoute(w routeWindow, s hotColdSplit, utimeMarginSec uint64) routeDe
 	if !w.sortDesc && start == nil {
 		return routeCold
 	}
-	// 4. Descending page that may contain NULL sort keys (externals): the
-	//    NULLS FIRST clamp needs the full historical set.
-	if w.canHaveNullKeys && w.sortDesc && start == nil {
-		return routeCold
-	}
-	// 5. Lower bound at or above the floor: whole window is in hot, a short
+	// 4. Lower bound at or above the floor: whole window is in hot, a short
 	//    page is a legitimate full answer.
 	if start != nil && *start >= hotFloor {
 		return routeHot
 	}
-	// 6. Descending, no lower bound: hot likely has the page; verify, rerun on
+	// 5. Descending, no lower bound: hot likely has the page; verify, rerun on
 	//    cold if it crossed the floor.
 	return routeHotVerify
 }
@@ -74,12 +68,11 @@ func verifyHotPage(orderKeys []*uint64, limit int, floor uint64) bool {
 		if k == nil {
 			return false // NULL sort key: position vs floor unknown
 		}
+		if *k < floor {
+			return false // page crosses below the split floor
+		}
 	}
-	if len(orderKeys) == 0 {
-		return true // limit 0
-	}
-	last := orderKeys[len(orderKeys)-1]
-	return *last >= floor
+	return true
 }
 
 // resolveRouted records the chosen path before a possible cold read.

--- a/ton-index-go/main.go
+++ b/ton-index-go/main.go
@@ -501,7 +501,7 @@ func GetTransactionsByMessage(c *fiber.Ctx) error {
 // @param only_externals query bool false "Return only external messages."
 // @param limit query int32 false "Limit number of queried rows. Use with *offset* to batch read." minimum(1) maximum(1000) default(10)
 // @param offset query int32 false "Skip first N rows. Use with *limit* to batch read." minimum(0) default(0)
-// @param sort query string false "Sort transactions by lt. If set to `desc`, you better set `start_lt = 1` to get latest messages." Enums(asc, desc) default(desc)
+// @param sort query string false "Sort messages by effective LT: `created_lt` for internal/external-out messages and the receiving transaction LT for external-in messages." Enums(asc, desc) default(desc)
 // @router			/api/v3/messages [get]
 // @security		APIKeyHeader
 // @security		APIKeyQuery

--- a/ton-index-worker/ton-index-postgres/src/migrate.cpp
+++ b/ton-index-worker/ton-index-postgres/src/migrate.cpp
@@ -1645,13 +1645,14 @@ create index if not exists jetton_transfers_index_9 on jetton_transfers (tx_lt);
 
 create index if not exists messages_index_1 on messages (msg_hash);
 create index if not exists messages_index_2 on messages (trace_id, tx_lt);
-create index if not exists messages_index_3 on messages (source, created_lt);
-create index if not exists messages_index_4 on messages (opcode, created_lt);
 create index if not exists messages_index_5 on messages (created_at, msg_hash);
-create index if not exists messages_index_6 on messages (created_lt, msg_hash);
-create index if not exists messages_index_7 on messages (destination, created_lt);
 create index if not exists messages_index_8 on messages (body_hash);
 create index if not exists messages_index_9 on messages (msg_hash_norm) where msg_hash_norm is not null;
+create index if not exists messages_order_lt_v2_idx on messages ((coalesce(created_lt, tx_lt)), msg_hash);
+create index if not exists messages_source_order_lt_v2_idx on messages (source, (coalesce(created_lt, tx_lt)), msg_hash);
+create index if not exists messages_destination_order_lt_v2_idx on messages (destination, (coalesce(created_lt, tx_lt)), msg_hash);
+create index if not exists messages_opcode_order_lt_v2_idx on messages (opcode, (coalesce(created_lt, tx_lt)), msg_hash);
+create index if not exists messages_destination_opcode_order_lt_v2_idx on messages (destination, opcode, (coalesce(created_lt, tx_lt)), msg_hash);
 
 create index if not exists nft_transfers_index_1 on nft_transfers (nft_item_address, tx_lt);
 create index if not exists nft_transfers_index_2 on nft_transfers (nft_collection_address, tx_now);


### PR DESCRIPTION
- messages index move from `created_lt` to `coalesce(created_lt, tx_lt)`
- messages ordering now includes external-in messages using receiving transaction LT
- actions filters are combined instead of overwriting each other
- traces with `mc_seqno` are queried from the database that owns the requested block
- hot/cold page verification uses the effective ordering key
- unnecessary PostgreSQL enrichment connections are skipped when enrichment is disabled