### PR TITLE
event_classifier: fix high cpu consumption

### DIFF
--- a/indexer/event_classifier.py
+++ b/indexer/event_classifier.py
@@ -8,7 +8,6 @@ import multiprocessing as mp
 import sys
 import time
 import traceback
-from datetime import datetime
 from datetime import timedelta
 from multiprocessing import Manager
 from typing import List, Tuple
@@ -120,6 +119,7 @@ class UnclassifiedEventsReader(mp.Process):
         batches = self._split_tasks_into_batches(tasks)
         for batch in batches:
             self.task_queue.put(batch)
+        return len(tasks)
 
     def _split_tasks_into_batches(self, tasks: List[ClassifierTask]) -> List[List[ClassifierTask]]:
         trace_tasks_batch = []
@@ -137,7 +137,8 @@ class UnclassifiedEventsReader(mp.Process):
     def run(self):
         try:
             while True:
-                self.read_batch()
+                if self.read_batch() == 0:
+                    time.sleep(0.1)
         except KeyboardInterrupt:
             logger.info(f'Gracefully stopped in the UnclassifiedEventsReader')
         except:
@@ -147,55 +148,12 @@ class UnclassifiedEventsReader(mp.Process):
 # end class
 
 
-class FinishedTasksProcessor(mp.Process):
-    def __init__(self, finished_queue: mp.Queue):
-        super().__init__()
-        self.finished_queue = finished_queue
-        self.last_commit = datetime.now()
-        logger.info(f"Reading finished tasks")
-
-    def read_finished_tasks(self):
-        tasks = []
-        while (datetime.now() - self.last_commit).total_seconds() < 10:
-            try:
-                result = self.finished_queue.get(timeout=1)
-                tasks.append(result)
-            except:
-                pass
-        if len(tasks) > 0:
-            with SyncSessionMaker() as session:
-                try:
-                    tasks_str = ','.join([f'{x}' for x in tasks])
-                    sql = f'delete from _classifier_tasks where id in ({tasks_str});'
-                    logger.info(f'sql: {sql}')
-                    logger.info(f'Closed {len(tasks)} finished tasks')
-                    result = session.execute(sql)
-                    session.commit()
-                except Exception as ee:
-                    logger.warning(f'Failed to close tasks: {ee}')
-                    session.rollback()
-                self.last_commit = datetime.now()
-
-    def run(self):
-        try:
-            while True:
-                self.read_finished_tasks()
-        except KeyboardInterrupt:
-            logger.info(f'Gracefully stopped in the FinishedTasksProcessor')
-        except:
-            logger.info(f'Error in FinishedTasksProcessor: {traceback.format_exc()}')
-        logger.info(f'Thread FinishedTasksProcessor finished')
-        return
-# end class
-
-
 class EventClassifierWorker(mp.Process):
-    def __init__(self, id: int, task_queue: mp.Queue, result_queue: mp.Queue, finished_queue: mp.Queue, shared_namespace, big_traces_threshold=4000, force=False):
+    def __init__(self, id: int, task_queue: mp.Queue, result_queue: mp.Queue, shared_namespace, big_traces_threshold=4000, force=False):
         super().__init__()
         self.id = id
         self.task_queue = task_queue
         self.result_queue = result_queue
-        self.finished_queue = finished_queue
         self.shared_namespace = shared_namespace
         self.big_traces_threshold = big_traces_threshold
         self.force = force
@@ -351,8 +309,6 @@ class EventClassifierWorker(mp.Process):
                 task_ids = [task.id for task in tasks]
                 await session.execute(f"delete from _classifier_tasks where id in ({','.join(map(str, task_ids))});")
                 await session.commit()
-                # for task in tasks:
-                #     self.finished_queue.put(task.id)
             except Exception as ee:
                 logger.error(f'Failed to process batch: {ee}')
                 await session.rollback()
@@ -392,21 +348,16 @@ async def start_processing_events_from_db(args: argparse.Namespace, shared_names
             total_traces = query.count()
         logger.info(f"Total unclassified traces from database: {total_traces}")
 
-    await start_pools_background_updater(redis.client)
-
     task_queue = mp.Queue(args.prefetch_size)
     result_queue = mp.Queue()
     stats_queue = mp.Queue()
-    finished_queue = mp.Queue()
     thread = UnclassifiedEventsReader(task_queue, result_queue, stats_queue, args.batch_size, args.prefetch_size)
     thread.start()
     workers = []
     for id in range(args.pool_size):
-        worker = EventClassifierWorker(id, task_queue, result_queue, finished_queue, shared_namespace, big_traces_threshold=4000)
+        worker = EventClassifierWorker(id, task_queue, result_queue, shared_namespace, big_traces_threshold=4000)
         worker.start()
         workers.append(worker)
-    task_closer = FinishedTasksProcessor(finished_queue)
-    task_closer.start()
 
     # stats
     failed_tasks = 0
@@ -448,8 +399,6 @@ async def start_processing_events_from_db(args: argparse.Namespace, shared_names
     for worker in workers:
         worker.terminate()
         worker.join()
-    task_closer.terminate()
-    task_closer.join()
     return
 # end def
 


### PR DESCRIPTION
- removed dead FinishedTasksProcessor (- ~1 cpu)
- add 100ms sleep on empty batch (lower db pressure - ~0.3 cpu)
- removed duplicate start_pools_background_updater() call

Improvements:

- classifier: 151.24% → 1.00% CPU;
- PostgreSQL: 39.38% → 0.91% CPU;
- PostgreSQL txs: ≈3062/s → ≈11/s;
- classifier memory: 156.5 → 138 MiB;